### PR TITLE
PNW-1326 - CMS fork migration

### DIFF
--- a/dev-test/config.yml
+++ b/dev-test/config.yml
@@ -5,6 +5,15 @@ site_url: https://example.com
 
 publish_mode: editorial_workflow
 media_folder: assets/uploads
+media_validation:
+  # max_file_size: 200
+  # file_name_pattern: ""
+  keep_file_name: true
+  images:
+    keep_aspect_ratio: true
+    # aspect_ratio: "16:9"
+    # max_width: 2000
+    # max_height: 2000
 
 collections: # A list of collections the CMS should be able to edit
   - name: 'posts' # Used in routes, ie.: /admin/collections/:slug/edit
@@ -40,6 +49,7 @@ collections: # A list of collections the CMS should be able to edit
           label: 'Publish Date',
           name: 'date',
           widget: 'datetime',
+          default: '',
           date_format: 'YYYY-MM-DD',
           time_format: 'HH:mm',
           format: 'YYYY-MM-DD HH:mm',
@@ -49,6 +59,19 @@ collections: # A list of collections the CMS should be able to edit
         widget: 'image'
         required: false
         tagname: ''
+        media_folder: 'src/assets/img/foo'
+        public_folder: '/assets/img/foo'
+        media_validation:
+          # max_file_size: 200000
+          file_extensions: ['jpg']
+          # file_name_pattern: "pepe[0-9]*\\..*"
+          # keep_file_name: false
+          images:
+            max_width: 2000
+            min_width: 451
+            max_height: 2000
+            # aspect_ratio: "16:9"
+          #   keep_aspect_ratio: true
 
       - { label: 'Body', name: 'body', widget: 'markdown', hint: 'Main content goes here.' }
 

--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
     "npm-run-all": "^4.1.5",
     "postcss": "^8.4.7",
     "postcss-scss": "^4.0.3",
-    "prettier": "^2.3.0",
+    "prettier": "^2.8.8",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
     "react-test-renderer": "^16.8.4",

--- a/packages/netlify-cms-backend-azure/src/implementation.ts
+++ b/packages/netlify-cms-backend-azure/src/implementation.ts
@@ -10,6 +10,7 @@ import {
   runWithLock,
   unpublishedEntries,
   entriesByFiles,
+  filterByIndexFile,
   filterByExtension,
   branchFromContentKey,
   entriesByFolder,
@@ -155,10 +156,14 @@ export default class Azure implements Implementation {
     return Promise.resolve(this.token);
   }
 
-  async entriesByFolder(folder: string, extension: string, depth: number) {
+  async entriesByFolder(folder: string, extension: string, depth: number, indexFile: string) {
     const listFiles = async () => {
       const files = await this.api!.listFiles(folder, depth > 1);
-      const filtered = files.filter(file => filterByExtension({ path: file.path }, extension));
+      const filtered = files.filter(
+        file =>
+          filterByIndexFile({ path: file.path }, indexFile) &&
+          filterByExtension({ path: file.path }, extension),
+      );
       return filtered.map(file => ({
         id: file.id,
         path: file.path,

--- a/packages/netlify-cms-backend-git-gateway/src/implementation.ts
+++ b/packages/netlify-cms-backend-git-gateway/src/implementation.ts
@@ -389,11 +389,11 @@ export default class GitGateway implements Implementation {
     return this.tokenPromise!();
   }
 
-  async entriesByFolder(folder: string, extension: string, depth: number) {
-    return this.backend!.entriesByFolder(folder, extension, depth);
+  async entriesByFolder(folder: string, extension: string, depth: number, indexFile: string) {
+    return this.backend!.entriesByFolder(folder, extension, depth, indexFile);
   }
-  allEntriesByFolder(folder: string, extension: string, depth: number) {
-    return this.backend!.allEntriesByFolder(folder, extension, depth);
+  allEntriesByFolder(folder: string, extension: string, depth: number, indexFile: string) {
+    return this.backend!.allEntriesByFolder(folder, extension, depth, indexFile);
   }
   entriesByFiles(files: ImplementationFile[]) {
     return this.backend!.entriesByFiles(files);

--- a/packages/netlify-cms-backend-github/src/implementation.tsx
+++ b/packages/netlify-cms-backend-github/src/implementation.tsx
@@ -13,6 +13,7 @@ import {
   unpublishedEntries,
   getMediaDisplayURL,
   getMediaAsBlob,
+  filterByIndexFile,
   filterByExtension,
   getPreviewStatus,
   runWithLock,
@@ -39,6 +40,8 @@ import type {
   ImplementationFile,
   UnpublishedEntryMediaFile,
   Entry,
+  ApiRequest,
+  GoogleCredentials
 } from 'netlify-cms-lib-util';
 import type { Semaphore } from 'semaphore';
 
@@ -62,9 +65,11 @@ type GitHubStatusComponent = {
 export default class GitHub implements Implementation {
   lock: AsyncLock;
   api: API | null;
+  updateUserCredentials: (args: Credentials) => Promise<null>;
   options: {
     proxied: boolean;
     API: API | null;
+    updateUserCredentials: (args: Credentials) => Promise<null>;
     useWorkflow?: boolean;
     initialWorkflowStatus: string;
   };
@@ -81,6 +86,11 @@ export default class GitHub implements Implementation {
   squashMerges: boolean;
   cmsLabelPrefix: string;
   useGraphql: boolean;
+  useApps: boolean;
+  appsApiRoot?: string;
+  appsApiLogin?: string;
+  appsAPIToken?: string;
+  googleAuth?: GoogleCredentials | null
   _currentUserPromise?: Promise<GitHubUser>;
   _userIsOriginMaintainerPromises?: {
     [key: string]: Promise<boolean>;
@@ -91,6 +101,7 @@ export default class GitHub implements Implementation {
     this.options = {
       proxied: false,
       API: null,
+      updateUserCredentials: async () => null,
       initialWorkflowStatus: '',
       ...options,
     };
@@ -103,6 +114,8 @@ export default class GitHub implements Implementation {
     }
 
     this.api = this.options.API || null;
+
+    this.updateUserCredentials = this.options.updateUserCredentials;
 
     this.openAuthoringEnabled = config.backend.open_authoring || false;
     if (this.openAuthoringEnabled) {
@@ -125,6 +138,12 @@ export default class GitHub implements Implementation {
     this.mediaFolder = config.media_folder;
     this.previewContext = config.backend.preview_context || '';
     this.lock = asyncLock();
+    this.useApps = Boolean(config.backend.apps_api_root);
+    if (this.useApps) {
+      this.appsApiRoot = config.backend.apps_api_root as string;
+      this.appsApiLogin = `${this.appsApiRoot}/${config.backend.apps_login_path || 'login'}`;
+      this.appsAPIToken = `${this.appsApiRoot}/${config.backend.apps_token_path || 'access_token'}`;
+    }
   }
 
   isGitBackend() {
@@ -172,11 +191,26 @@ export default class GitHub implements Implementation {
     return wrappedAuthenticationPage;
   }
 
+  appsRequestFunction = async (req: ApiRequest) => {
+    const request = await unsentRequest.performRequest(req);
+    if (request.status === 401) {
+      const newToken = await this.getRefreshedAccessToken();
+      const reqWithNewToken = unsentRequest.withHeaders(
+        {
+          Authorization: `Bearer ${newToken}`,
+        },
+        req,
+      ) as ApiRequest;
+      return unsentRequest.performRequest(reqWithNewToken);
+    }
+    return request;
+  };
+
   restoreUser(user: User) {
     return this.openAuthoringEnabled
       ? this.authenticateWithFork({ userData: user, getPermissionToFork: () => true }).then(() =>
-          this.authenticate(user),
-        )
+        this.authenticate(user),
+      )
       : this.authenticate(user);
   }
 
@@ -300,11 +334,14 @@ export default class GitHub implements Implementation {
 
   async authenticate(state: Credentials) {
     this.token = state.token as string;
+    this.googleAuth = state.google_auth;
     const apiCtor = this.useGraphql ? GraphQLAPI : API;
     this.api = new apiCtor({
       token: this.token,
+      googleAuth: this.googleAuth,
       branch: this.branch,
       repo: this.repo,
+      requestFunction: this.useApps ? this.appsRequestFunction : unsentRequest.performRequest,
       originRepo: this.originRepo,
       apiRoot: this.apiRoot,
       squashMerges: this.squashMerges,
@@ -313,7 +350,7 @@ export default class GitHub implements Implementation {
       initialWorkflowStatus: this.options.initialWorkflowStatus,
     });
     const user = await this.api!.user();
-    const isCollab = await this.api!.hasWriteAccess().catch(error => {
+    const isCollab = this.useApps || await this.api!.hasWriteAccess().catch(error => {
       error.message = stripIndent`
         Repo "${this.repo}" not found.
 
@@ -333,11 +370,32 @@ export default class GitHub implements Implementation {
     }
 
     // Authorized user
-    return { ...user, token: state.token as string, useOpenAuthoring: this.useOpenAuthoring };
+    return { ...user, token: state.token as string, google_auth: state.google_auth, useOpenAuthoring: this.useOpenAuthoring };
+  }
+
+  updateToken(token: string) {
+    this.token = token;
+    this.api!.token = token;
+    this.updateUserCredentials({ token });
+    return token
+  }
+
+  async getRefreshedAccessToken() {
+    const tokenInfo = await fetch(this.appsAPIToken, {
+      method: 'POST',
+      body: JSON.stringify({
+        repo: this.repo
+      }),
+      headers: {
+        Authorization: `token ${this.googleAuth!.token}`,
+      }
+    })
+    return this.updateToken((await tokenInfo.json()).token)
   }
 
   logout() {
     this.token = null;
+    this.googleAuth = null;
     if (this.api && this.api.reset && typeof this.api.reset === 'function') {
       return this.api.reset();
     }
@@ -371,7 +429,7 @@ export default class GitHub implements Implementation {
     return { cursor, files: pageFiles };
   };
 
-  async entriesByFolder(folder: string, extension: string, depth: number) {
+  async entriesByFolder(folder: string, extension: string, depth: number, indexFile: string) {
     const repoURL = this.api!.originRepoURL;
 
     let cursor: Cursor;
@@ -381,7 +439,9 @@ export default class GitHub implements Implementation {
         repoURL,
         depth,
       }).then(files => {
-        const filtered = files.filter(file => filterByExtension(file, extension));
+        const filtered = files.filter(
+          file => filterByIndexFile(file, indexFile) && filterByExtension(file, extension),
+        );
         const result = this.getCursorAndFiles(filtered, 1);
         cursor = result.cursor;
         return result.files;
@@ -402,14 +462,18 @@ export default class GitHub implements Implementation {
     return files;
   }
 
-  async allEntriesByFolder(folder: string, extension: string, depth: number) {
+  async allEntriesByFolder(folder: string, extension: string, depth: number, indexFile: string) {
     const repoURL = this.api!.originRepoURL;
 
     const listFiles = () =>
       this.api!.listFiles(folder, {
         repoURL,
         depth,
-      }).then(files => files.filter(file => filterByExtension(file, extension)));
+      }).then(files =>
+        files.filter(
+          file => filterByIndexFile(file, indexFile) && filterByExtension(file, extension),
+        ),
+      );
 
     const readFile = (path: string, id: string | null | undefined) => {
       return this.api!.readFile(path, id, { repoURL }) as Promise<string>;

--- a/packages/netlify-cms-backend-test/src/implementation.ts
+++ b/packages/netlify-cms-backend-test/src/implementation.ts
@@ -141,6 +141,10 @@ export default class TestBackend implements Implementation {
     return Promise.resolve({ auth: { status: true }, api: { status: true, statusPage: '' } });
   }
 
+  mainStatus() {
+    return Promise.resolve({ status: '', updatedAt: '' });
+  }
+
   authComponent() {
     return AuthenticationPage;
   }

--- a/packages/netlify-cms-core/index.d.ts
+++ b/packages/netlify-cms-core/index.d.ts
@@ -121,6 +121,7 @@ declare module 'netlify-cms-core' {
     default?: string;
 
     media_library?: CmsMediaLibrary;
+    media_validation?: CmsMediaValidation;
     allow_multiple?: boolean;
     choose_url?: boolean;
     config?: any;
@@ -485,6 +486,23 @@ declare module 'netlify-cms-core' {
     name: string;
     config?: CmsMediaLibraryOptions;
   }
+
+export interface CmsMediaImageValidation {
+  aspect_ratio: string
+  keep_aspect_ratio: boolean;
+  max_width: number
+  max_height: number
+  min_width: number
+  min_height: number
+}
+
+export interface CmsMediaValidation {
+  file_extensions: Array<string>
+  keep_file_name: boolean
+  max_file_size: number
+  file_name_pattern: string
+  images?: CmsMediaImageValidation;
+}
 
   export interface CmsEventListener {
     name: 'prePublish' | 'postPublish' | 'preUnpublish' | 'postUnpublish' | 'preSave' | 'postSave';

--- a/packages/netlify-cms-core/package.json
+++ b/packages/netlify-cms-core/package.json
@@ -36,6 +36,7 @@
     "fuzzy": "^0.1.1",
     "gotrue-js": "^0.9.24",
     "gray-matter": "^4.0.2",
+    "prettier": "^2.8.8",
     "history": "^4.7.2",
     "immer": "^9.0.0",
     "js-base64": "^3.0.0",

--- a/packages/netlify-cms-core/src/actions/auth.ts
+++ b/packages/netlify-cms-core/src/actions/auth.ts
@@ -1,6 +1,7 @@
 import { actions as notifActions } from 'redux-notifications';
 
 import { currentBackend } from '../backend';
+import { checkMainStatus } from './main';
 
 import type { Credentials, User } from 'netlify-cms-lib-util';
 import type { ThunkDispatch } from 'redux-thunk';
@@ -67,7 +68,9 @@ export function authenticateUser() {
           if (user.useOpenAuthoring) {
             dispatch(useOpenAuthoring());
           }
-          dispatch(authenticate(user));
+          dispatch(checkMainStatus()).then(() => {
+            dispatch(authenticate(user));
+          });
         } else {
           dispatch(doneAuthenticating());
         }
@@ -91,7 +94,9 @@ export function loginUser(credentials: Credentials) {
         if (user.useOpenAuthoring) {
           dispatch(useOpenAuthoring());
         }
-        dispatch(authenticate(user));
+        dispatch(checkMainStatus()).then(() => {
+          dispatch(authenticate(user));
+        });
       })
       .catch((error: Error) => {
         console.error(error);

--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.ts
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.ts
@@ -268,7 +268,7 @@ export function loadUnpublishedEntry(collection: Collection, slug: string) {
             }),
           ),
       );
-      dispatch(addAssets(assetProxies));
+      dispatch(addAssets(entry, assetProxies));
       dispatch(unpublishedEntryLoaded(collection, entry));
       dispatch(createDraftFromEntry(entry));
     } catch (error) {

--- a/packages/netlify-cms-core/src/actions/editorialWorkflow.ts
+++ b/packages/netlify-cms-core/src/actions/editorialWorkflow.ts
@@ -25,6 +25,7 @@ import { addAssets } from './media';
 import { loadMedia } from './mediaLibrary';
 import ValidationErrorTypes from '../constants/validationErrorTypes';
 import { navigateToEntry } from '../routing/history';
+import { checkMainStatus } from './main';
 
 import type {
   Collection,
@@ -481,7 +482,11 @@ export function deleteUnpublishedEntry(collection: string, slug: string) {
   };
 }
 
-export function publishUnpublishedEntry(collectionName: string, slug: string) {
+export function publishUnpublishedEntry(
+  collectionName: string,
+  slug: string,
+  publishMain: boolean,
+) {
   return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
     const state = getState();
     const collections = state.collections;
@@ -489,8 +494,10 @@ export function publishUnpublishedEntry(collectionName: string, slug: string) {
     const entry = selectUnpublishedEntry(state, collectionName, slug);
     dispatch(unpublishedEntryPublishRequest(collectionName, slug));
     try {
-      await backend.publishUnpublishedEntry(entry);
-      // re-load media after entry was published
+      await backend.publishUnpublishedEntry(entry, publishMain);
+
+      await dispatch(checkMainStatus());
+
       dispatch(loadMedia());
       dispatch(
         notifSend({

--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -84,6 +84,7 @@ export const ENTRY_DELETE_SUCCESS = 'ENTRY_DELETE_SUCCESS';
 export const ENTRY_DELETE_FAILURE = 'ENTRY_DELETE_FAILURE';
 
 export const ADD_DRAFT_ENTRY_MEDIA_FILE = 'ADD_DRAFT_ENTRY_MEDIA_FILE';
+export const REMOVE_DRAFT_ENTRY_MEDIA_FILES = 'REMOVE_DRAFT_ENTRY_MEDIA_FILES';
 export const REMOVE_DRAFT_ENTRY_MEDIA_FILE = 'REMOVE_DRAFT_ENTRY_MEDIA_FILE';
 
 export const CHANGE_VIEW_STYLE = 'CHANGE_VIEW_STYLE';
@@ -454,6 +455,10 @@ export function addDraftEntryMediaFile(file: ImplementationMediaFile) {
   return { type: ADD_DRAFT_ENTRY_MEDIA_FILE, payload: file };
 }
 
+export function removeDraftEntryMediaFiles() {
+  return { type: REMOVE_DRAFT_ENTRY_MEDIA_FILES };
+}
+
 export function removeDraftEntryMediaFile({ id }: { id: string }) {
   return { type: REMOVE_DRAFT_ENTRY_MEDIA_FILE, payload: { id } };
 }
@@ -506,7 +511,7 @@ export function retrieveLocalBackup(collection: Collection, slug: string) {
           }
         }),
       );
-      dispatch(addAssets(assetProxies));
+      dispatch(addAssets(entry, assetProxies));
 
       return dispatch(localBackupRetrieved(entry));
     }

--- a/packages/netlify-cms-core/src/actions/main.ts
+++ b/packages/netlify-cms-core/src/actions/main.ts
@@ -1,0 +1,195 @@
+import { actions as notifActions } from 'redux-notifications';
+
+import { currentBackend } from '../backend';
+
+import type { ThunkDispatch } from 'redux-thunk';
+import type { AnyAction } from 'redux';
+import type { State } from '../types/redux';
+
+export const STATUS_MAIN_REQUEST = 'STATUS_MAIN_REQUEST';
+export const STATUS_MAIN_SUCCESS = 'STATUS_MAIN_SUCCESS';
+export const STATUS_MAIN_FAILURE = 'STATUS_MAIN_FAILURE';
+
+export const CLOSE_MAIN_REQUEST = 'CLOSE_MAIN_REQUEST';
+export const CLOSE_MAIN_SUCCESS = 'CLOSE_MAIN_SUCCESS';
+export const CLOSE_MAIN_FAILURE = 'CLOSE_MAIN_FAILURE';
+
+export const PUBLISH_MAIN_REQUEST = 'PUBLISH_MAIN_REQUEST';
+export const PUBLISH_MAIN_SUCCESS = 'PUBLISH_MAIN_SUCCESS';
+export const PUBLISH_MAIN_FAILURE = 'PUBLISH_MAIN_FAILURE';
+
+const { notifSend } = notifActions;
+
+export function mainStatusRequest() {
+  return {
+    type: STATUS_MAIN_REQUEST,
+  } as const;
+}
+
+export function mainStatusSuccess(status: { status?: string; updatedAt?: string } = {}) {
+  return {
+    type: STATUS_MAIN_SUCCESS,
+    payload: { status },
+  } as const;
+}
+
+export function mainStatusFailure(error: Error) {
+  return {
+    type: STATUS_MAIN_FAILURE,
+    payload: { error },
+  } as const;
+}
+export function mainPublishRequest() {
+  return {
+    type: PUBLISH_MAIN_REQUEST,
+  } as const;
+}
+
+export function mainPublishSuccess() {
+  return {
+    type: PUBLISH_MAIN_SUCCESS,
+  } as const;
+}
+
+export function mainPublishFailure() {
+  return {
+    type: PUBLISH_MAIN_FAILURE,
+  } as const;
+}
+
+export function mainCloseRequest() {
+  return {
+    type: CLOSE_MAIN_REQUEST,
+  } as const;
+}
+
+export function mainCloseSuccess() {
+  return {
+    type: CLOSE_MAIN_SUCCESS,
+  } as const;
+}
+
+export function mainCloseFailure() {
+  return {
+    type: CLOSE_MAIN_FAILURE,
+  } as const;
+}
+
+export function checkMainStatus() {
+  return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
+    try {
+      const state = getState();
+      if (state.main.isFetching || !state.config.backend.main) {
+        return;
+      }
+      dispatch(mainStatusRequest());
+
+      const backend = currentBackend(state.config);
+      const mainStatus = await backend.mainStatus();
+
+      dispatch(mainStatusSuccess(mainStatus));
+    } catch (error) {
+      dispatch(mainStatusFailure(error));
+    }
+  };
+}
+
+export function updateMainStatus(oldStatus: string, newStatus: string) {
+  return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
+    try {
+      if (oldStatus === newStatus) return;
+      const state = getState();
+      if (state.main.isFetching || !state.config.backend.main) {
+        return;
+      }
+      dispatch(mainStatusRequest());
+
+      const backend = currentBackend(state.config);
+      await backend.updateMainStatus(newStatus);
+
+      const mainStatus = await backend.mainStatus();
+      dispatch(mainStatusSuccess(mainStatus));
+      dispatch(
+        notifSend({
+          message: {
+            key: 'ui.toast.mainUpdated',
+          },
+          kind: 'success',
+          dismissAfter: 4000,
+        }),
+      );
+    } catch (error) {
+      dispatch(mainStatusFailure(error));
+    }
+  };
+}
+
+export function publishMain() {
+  return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
+    try {
+      const state = getState();
+      if (state.main.isFetching || !state.config.backend.main) {
+        return;
+      }
+      dispatch(mainPublishRequest());
+
+      const backend = currentBackend(state.config);
+      await backend.publishMain();
+
+      dispatch(mainStatusSuccess({}));
+      dispatch(mainPublishSuccess());
+      dispatch(
+        notifSend({
+          message: {
+            key: 'ui.toast.mainPublished',
+          },
+          kind: 'success',
+          dismissAfter: 4000,
+        }),
+      );
+    } catch (error) {
+      dispatch(mainPublishFailure(error));
+    }
+  };
+}
+
+export function closeMain() {
+  return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
+    try {
+      const state = getState();
+      if (state.main.isFetching || !state.config.backend.main) {
+        return;
+      }
+      dispatch(mainCloseRequest());
+
+      const backend = currentBackend(state.config);
+      await backend.closeMain();
+
+      dispatch(mainStatusSuccess({}));
+      dispatch(mainCloseSuccess());
+      dispatch(
+        notifSend({
+          message: {
+            key: 'ui.toast.mainClosed',
+          },
+          kind: 'success',
+          dismissAfter: 4000,
+        }),
+      );
+    } catch (error) {
+      dispatch(mainCloseFailure(error));
+    }
+  };
+}
+
+export type MainStatusAction = ReturnType<
+  | typeof mainStatusRequest
+  | typeof mainStatusSuccess
+  | typeof mainStatusFailure
+  | typeof mainPublishRequest
+  | typeof mainPublishSuccess
+  | typeof mainPublishFailure
+  | typeof mainCloseRequest
+  | typeof mainCloseSuccess
+  | typeof mainCloseFailure
+>;

--- a/packages/netlify-cms-core/src/actions/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/actions/mediaLibrary.ts
@@ -114,29 +114,6 @@ export function closeMediaLibrary() {
   };
 }
 
-function checkMediaString(mediaPath: string, field: EntryField | undefined) {
-  const mediaBasename = basename(mediaPath);
-  const fileName = field?.get('file_name');
-  if (fileName && mediaBasename !== fileName) {
-    throw new Error(`The name of the file must be ${fileName}!`);
-  }
-}
-
-export function checkMedia(mediaPath: string | string[], field: EntryField | undefined) {
-  return () => {
-    try {
-      if (Array.isArray(mediaPath)) {
-        mediaPath.forEach(path => checkMediaString(path, field));
-      } else {
-        checkMediaString(mediaPath, field);
-      }
-      return true;
-    } catch (e) {
-      window.alert(e);
-    }
-  }
-}
-
 export function insertMedia(mediaPath: string | string[], field: EntryField | undefined) {
   return (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
     const state = getState();

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -307,6 +307,10 @@ function collectionDepth(collection: Collection) {
   return depth;
 }
 
+function collectionIndexFile(collection: Collection) {
+  return collection.get('meta')?.get('path')?.get('index_file') as string;
+}
+
 export class Backend {
   implementation: Implementation;
   backendName: string;
@@ -505,10 +509,12 @@ export class Backend {
     if (collectionType === FOLDER) {
       listMethod = () => {
         const depth = collectionDepth(collection);
+        const indexFile = collectionIndexFile(collection);
         return this.implementation.entriesByFolder(
           collection.get('folder') as string,
           extension,
           depth,
+          indexFile,
         );
       };
     } else if (collectionType === FILES) {
@@ -550,9 +556,10 @@ export class Backend {
   async listAllEntries(collection: Collection) {
     if (collection.get('folder') && this.implementation.allEntriesByFolder) {
       const depth = collectionDepth(collection);
+      const indexFile = collectionIndexFile(collection);
       const extension = selectFolderEntryExtension(collection);
       return this.implementation
-        .allEntriesByFolder(collection.get('folder') as string, extension, depth)
+        .allEntriesByFolder(collection.get('folder') as string, extension, depth, indexFile)
         .then(entries => this.processEntries(entries, collection));
     }
 

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -878,7 +878,7 @@ export class Backend {
     }
 
     const dataFiles = sortBy(
-      entryData.diffs.filter(d => d.path.endsWith(extension)),
+      entryData.diffs.filter(d => d.path.endsWith(extension) && d.path.includes(slug)),
       f => f.path.length,
     );
 
@@ -1266,12 +1266,33 @@ export class Backend {
     return this.implementation.updateUnpublishedEntryStatus!(collection, slug, newStatus);
   }
 
-  async publishUnpublishedEntry(entry: EntryMap) {
+  async publishUnpublishedEntry(entry: EntryMap, publishMain?: boolean) {
     const collection = entry.get('collection');
     const slug = entry.get('slug');
 
     await this.invokePrePublishEvent(entry);
-    await this.implementation.publishUnpublishedEntry!(collection, slug);
+
+    const config = this.config;
+    if (config.backend.main) {
+      const user = (await this.currentUser()) as User;
+      const mainCommitMessage = commitMessageFormatter(
+        'main',
+        config,
+        {
+          main: config.backend.main,
+          authorLogin: user.login,
+          authorName: user.name,
+        },
+        user.useOpenAuthoring,
+      );
+      await this.implementation.publishUnpublishedEntryMain!(collection, slug, {
+        mainCommitMessage,
+        publishMain,
+      });
+    } else {
+      await this.implementation.publishUnpublishedEntry!(collection, slug);
+    }
+
     await this.invokePostPublishEvent(entry);
   }
 
@@ -1317,6 +1338,26 @@ export class Backend {
       }
       return fieldValue === filterRule.get('value');
     });
+  }
+
+  mainStatus() {
+    return this.implementation.mainStatus();
+  }
+
+  updateMainStatus(newStatus: string) {
+    return this.implementation.updateMainStatus(newStatus);
+  }
+
+  publishMain() {
+    return this.implementation.publishMain();
+  }
+
+  closeMain() {
+    return this.implementation.closeMain();
+  }
+
+  createMainPR() {
+    return this.implementation.createMainPR(this.config.backend.commit_messages?.main);
   }
 }
 

--- a/packages/netlify-cms-core/src/components/App/Header.js
+++ b/packages/netlify-cms-core/src/components/App/Header.js
@@ -7,9 +7,9 @@ import { translate } from 'react-polyglot';
 import { NavLink } from 'react-router-dom';
 import {
   Icon,
-  Dropdown,
-  DropdownItem,
-  StyledDropdownButton,
+  // Dropdown,
+  // DropdownItem,
+  // StyledDropdownButton,
   colors,
   lengths,
   shadows,
@@ -20,6 +20,8 @@ import { connect } from 'react-redux';
 
 import { SettingsDropdown } from '../UI';
 import { checkBackendStatus } from '../../actions/status';
+import { checkMainStatus } from '../../actions/main';
+import MainToolbar from './MainToolbar.js';
 
 const styles = {
   buttonActive: css`
@@ -97,16 +99,16 @@ const AppHeaderActions = styled.div`
   align-items: center;
 `;
 
-const AppHeaderQuickNewButton = styled(StyledDropdownButton)`
-  ${buttons.button};
-  ${buttons.medium};
-  ${buttons.gray};
-  margin-right: 8px;
+// const AppHeaderQuickNewButton = styled(StyledDropdownButton)`
+//   ${buttons.button};
+//   ${buttons.medium};
+//   ${buttons.gray};
+//   margin-right: 8px;
 
-  &:after {
-    top: 11px;
-  }
-`;
+//   &:after {
+//     top: 11px;
+//   }
+// `;
 
 const AppHeaderNavList = styled.ul`
   display: flex;
@@ -126,6 +128,7 @@ class Header extends React.Component {
     isTestRepo: PropTypes.bool,
     t: PropTypes.func.isRequired,
     checkBackendStatus: PropTypes.func.isRequired,
+    checkMainStatus: PropTypes.func.isRequired,
   };
 
   intervalId;
@@ -133,6 +136,7 @@ class Header extends React.Component {
   componentDidMount() {
     this.intervalId = setInterval(() => {
       this.props.checkBackendStatus();
+      this.props.checkMainStatus();
     }, 5 * 60 * 1000);
   }
 
@@ -150,7 +154,7 @@ class Header extends React.Component {
   render() {
     const {
       user,
-      collections,
+      // collections,
       onLogoutClick,
       openMediaLibrary,
       hasWorkflow,
@@ -160,9 +164,11 @@ class Header extends React.Component {
       showMediaButton,
     } = this.props;
 
-    const createableCollections = collections
-      .filter(collection => collection.get('create'))
-      .toList();
+    // const createableCollections = collections
+    //   .filter(collection => collection.get('create'))
+    //   .toList();
+
+    // console.log(Object.fromEntries(collections))
 
     return (
       <AppHeader>
@@ -198,7 +204,15 @@ class Header extends React.Component {
             </AppHeaderNavList>
           </nav>
           <AppHeaderActions>
-            {createableCollections.size > 0 && (
+            {hasWorkflow && (
+              <MainToolbar
+                hasWorkflow={hasWorkflow}
+                collection={new Map()}
+                loadDeployPreview={() => { }}
+              >
+              </MainToolbar>
+            )}
+            {/* {createableCollections.size > 0 && (
               <Dropdown
                 renderButton={() => (
                   <AppHeaderQuickNewButton> {t('app.header.quickAdd')}</AppHeaderQuickNewButton>
@@ -215,7 +229,7 @@ class Header extends React.Component {
                   />
                 ))}
               </Dropdown>
-            )}
+            )} */}
             <SettingsDropdown
               displayUrl={displayUrl}
               isTestRepo={isTestRepo}
@@ -231,6 +245,7 @@ class Header extends React.Component {
 
 const mapDispatchToProps = {
   checkBackendStatus,
+  checkMainStatus
 };
 
 export default connect(null, mapDispatchToProps)(translate()(Header));

--- a/packages/netlify-cms-core/src/components/App/MainToolbar.js
+++ b/packages/netlify-cms-core/src/components/App/MainToolbar.js
@@ -1,0 +1,272 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { css } from '@emotion/core';
+import styled from '@emotion/styled';
+import { translate } from 'react-polyglot';
+import {
+  Icon,
+  Dropdown,
+  DropdownItem,
+  StyledDropdownButton,
+  colorsRaw,
+  colors,
+  buttons,
+} from 'netlify-cms-ui-default';
+import { connect } from 'react-redux';
+
+import { updateMainStatus, publishMain, closeMain } from '../../actions/main';
+import { status } from '../../constants/publishModes';
+
+const styles = {
+  noOverflow: css`
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+  `,
+  buttonMargin: css`
+    margin: 0 10px;
+  `,
+  toolbarSection: css`
+    height: 100%;
+    display: flex;
+    align-items: center;
+    border: 0 solid ${colors.textFieldBorder};
+  `,
+  publishedButton: css`
+    background-color: ${colorsRaw.tealLight};
+    color: ${colorsRaw.teal};
+  `,
+};
+
+const DropdownButton = styled(StyledDropdownButton)`
+  ${styles.noOverflow}
+  @media (max-width: 1200px) {
+    padding-left: 10px;
+  }
+`;
+
+const ToolbarSectionMain = styled.div`
+  ${styles.toolbarSection};
+  flex: 10;
+  display: flex;
+  justify-content: space-between;
+  padding: 0 10px;
+`;
+
+const ToolbarSubSectionFirst = styled.div`
+  display: flex;
+  align-items: center;
+`;
+
+const ToolbarDropdown = styled(Dropdown)`
+  ${styles.buttonMargin};
+
+  ${Icon} {
+    color: ${colorsRaw.teal};
+  }
+`;
+
+const ToolbarButton = styled.button`
+  ${buttons.button};
+  ${buttons.default};
+  ${styles.buttonMargin};
+  ${styles.noOverflow};
+  display: block;
+
+  @media (max-width: 1200px) {
+    padding: 0 10px;
+  }
+`;
+
+const DeleteButton = styled(ToolbarButton)`
+  ${buttons.lightRed};
+`;
+
+const PublishButton = styled(DropdownButton)`
+  background-color: ${colorsRaw.teal};
+`;
+
+const StatusButton = styled(DropdownButton)`
+  background-color: ${colorsRaw.tealLight};
+  color: ${colorsRaw.teal};
+`;
+
+const StatusDropdownItem = styled(DropdownItem)`
+  ${Icon} {
+    color: ${colors.infoText};
+  }
+`;
+
+export class EditorToolbar extends React.Component {
+  static propTypes = {
+    isPersisting: PropTypes.bool,
+    isPublishing: PropTypes.bool,
+    isUpdatingStatus: PropTypes.bool,
+    isDeleting: PropTypes.bool,
+    onPersist: PropTypes.func.isRequired,
+    onPersistAndNew: PropTypes.func.isRequired,
+    onPersistAndDuplicate: PropTypes.func.isRequired,
+    showDelete: PropTypes.bool.isRequired,
+    unPublish: PropTypes.func.isRequired,
+    user: PropTypes.object,
+    useOpenAuthoring: PropTypes.bool,
+    currentStatus: PropTypes.string,
+    t: PropTypes.func.isRequired,
+  };
+
+  handleChangeStatus = newStatusName => {
+    const { updateMainStatus, currentStatus, } = this.props;
+    const newStatus = status.get(newStatusName);
+    updateMainStatus(currentStatus, newStatus);
+  };
+
+  handleDelete = () => {
+    const { closeMain, t } = this.props;
+    if (!window.confirm(t('editor.editor.onMainClosing'))) {
+      return;
+    }
+    closeMain();
+  };
+
+  handlePublish = () => {
+    const { publishMain, t } = this.props;
+    if (!window.confirm(t('editor.editor.onMainPublishing'))) {
+      return;
+    }
+    publishMain()
+  };
+
+  componentDidMount() {
+    const { isNewEntry, loadDeployPreview } = this.props;
+    if (!isNewEntry) {
+      loadDeployPreview({ maxAttempts: 3 });
+    }
+  }
+
+  componentDidUpdate(prevProps) {
+    const { isNewEntry, isPersisting, loadDeployPreview } = this.props;
+    if (!isNewEntry && prevProps.isPersisting && !isPersisting) {
+      loadDeployPreview({ maxAttempts: 3 });
+    }
+  }
+
+  renderWorkflowStatusControls = () => {
+    const { isUpdatingStatus, currentStatus, t, } = this.props;
+
+    const statusToTranslation = {
+      [status.get('DRAFT')]: t('editor.editorToolbar.draft'),
+      [status.get('PENDING_REVIEW')]: t('editor.editorToolbar.inReview'),
+      [status.get('PENDING_PUBLISH')]: t('editor.editorToolbar.ready'),
+    };
+
+    const buttonText = isUpdatingStatus
+      ? t('editor.editorToolbar.updating')
+      : t('editor.editorToolbar.status', { status: statusToTranslation[currentStatus] });
+
+    return (
+      <>
+        <ToolbarDropdown
+          dropdownTopOverlap="40px"
+          dropdownWidth="120px"
+          renderButton={() => <StatusButton>{buttonText}</StatusButton>}
+        >
+          <StatusDropdownItem
+            label={t('editor.editorToolbar.draft')}
+            onClick={() => this.handleChangeStatus('DRAFT')}
+            icon={currentStatus === status.get('DRAFT') ? 'check' : null}
+          />
+          <StatusDropdownItem
+            label={t('editor.editorToolbar.inReview')}
+            onClick={() => this.handleChangeStatus('PENDING_REVIEW')}
+            icon={currentStatus === status.get('PENDING_REVIEW') ? 'check' : null}
+          />
+          <StatusDropdownItem
+            label={t('editor.editorToolbar.ready')}
+            onClick={() => this.handleChangeStatus('PENDING_PUBLISH')}
+            icon={currentStatus === status.get('PENDING_PUBLISH') ? 'check' : null}
+          />
+        </ToolbarDropdown>
+      </>
+    );
+  };
+
+  renderNewEntryWorkflowPublishControls = () => {
+    const { isPublishing, t } = this.props;
+
+    return (
+      <ToolbarDropdown
+        dropdownTopOverlap="40px"
+        dropdownWidth="150px"
+        renderButton={() => (
+          <PublishButton>
+            {isPublishing
+              ? t('editor.editorToolbar.publishing')
+              : t('editor.editorToolbar.publish')}
+          </PublishButton>
+        )}
+      >
+        <DropdownItem
+          label={t('editor.editorToolbar.publishNow')}
+          icon="arrow"
+          iconDirection="right"
+          onClick={this.handlePublish}
+        />
+      </ToolbarDropdown>
+    )
+  };
+
+  renderWorkflowControls = () => {
+    const {
+      useOpenAuthoring,
+      isDeleting,
+      currentStatus,
+      collection,
+      t,
+    } = this.props;
+
+    const canCreate = collection.get('create');
+    const canPublish = collection.get('publish') && !useOpenAuthoring;
+
+    return [
+      currentStatus && [
+        this.renderWorkflowStatusControls(),
+        currentStatus === status.get('PENDING_PUBLISH') &&
+        this.renderNewEntryWorkflowPublishControls({ canCreate, canPublish }),
+        (
+          <DeleteButton
+            key="delete-button"
+            onClick={this.handleDelete}
+          >
+            {isDeleting ? t('editor.editorToolbar.discarding') : t('editor.editorToolbar.discardChanges')}
+          </DeleteButton>
+        ),
+      ],
+    ];
+  };
+
+  render() {
+    return (
+      <ToolbarSectionMain>
+        <ToolbarSubSectionFirst>
+          {this.renderWorkflowControls()}
+        </ToolbarSubSectionFirst>
+      </ToolbarSectionMain>
+    );
+  }
+}
+
+function mapStateToProps(state) {
+  const { status } = state.main;
+  return {
+    currentStatus: status.status,
+    ...status
+  }
+}
+
+const mapDispatchToProps = {
+  updateMainStatus,
+  publishMain,
+  closeMain
+};
+
+export default connect(mapStateToProps, mapDispatchToProps)(translate()(EditorToolbar));

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -22,6 +22,7 @@ import {
   loadLocalBackup,
   retrieveLocalBackup,
   deleteLocalBackup,
+  removeDraftEntryMediaFiles,
 } from '../../actions/entries';
 import {
   updateUnpublishedEntryStatus,
@@ -29,6 +30,7 @@ import {
   unpublishPublishedEntry,
   deleteUnpublishedEntry,
 } from '../../actions/editorialWorkflow';
+import { removeAssets } from '../../actions/media';
 import { loadDeployPreview } from '../../actions/deploys';
 import { selectEntry, selectUnpublishedEntry, selectDeployPreview } from '../../reducers';
 import { selectFields } from '../../reducers/collections';
@@ -189,6 +191,9 @@ export class Editor extends React.Component {
   componentWillUnmount() {
     this.createBackup.flush();
     this.props.discardDraft();
+    if (this.props.hasChanged) {
+      this.props.removeAssets();
+    }
     window.removeEventListener('beforeunload', this.exitBlocker);
   }
 
@@ -312,7 +317,7 @@ export class Editor extends React.Component {
   };
 
   handleDeleteUnpublishedChanges = async () => {
-    const { entryDraft, collection, slug, deleteUnpublishedEntry, loadEntry, isModification, t } =
+    const { entryDraft, collection, slug, removeAssets, removeDraftEntryMediaFiles, deleteUnpublishedEntry, loadEntry, isModification, t } =
       this.props;
     if (
       entryDraft.get('hasChanged') &&
@@ -322,6 +327,10 @@ export class Editor extends React.Component {
     } else if (!window.confirm(t('editor.editor.onDeleteUnpublishedChanges'))) {
       return;
     }
+
+    removeAssets();
+    removeDraftEntryMediaFiles();
+
     await deleteUnpublishedEntry(collection.get('name'), slug);
 
     this.deleteBackup();
@@ -488,6 +497,8 @@ const mapDispatchToProps = {
   publishUnpublishedEntry,
   unpublishPublishedEntry,
   deleteUnpublishedEntry,
+  removeAssets,
+  removeDraftEntryMediaFiles,
   logoutUser,
 };
 

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -166,18 +166,18 @@ export class Editor extends React.Component {
   }
 
   componentDidUpdate(prevProps) {
-    if (!prevProps.localBackup && this.props.localBackup) {
-      const confirmLoadBackup = window.confirm(this.props.t('editor.editor.confirmLoadBackup'));
-      if (confirmLoadBackup) {
-        this.props.loadLocalBackup();
-      } else {
-        this.deleteBackup();
-      }
-    }
+    // if (!prevProps.localBackup && this.props.localBackup) {
+    //   const confirmLoadBackup = window.confirm(this.props.t('editor.editor.confirmLoadBackup'));
+    //   if (confirmLoadBackup) {
+    //     this.props.loadLocalBackup();
+    //   } else {
+    //     this.deleteBackup();
+    //   }
+    // }
 
-    if (this.props.hasChanged) {
-      this.createBackup(this.props.entryDraft.get('entry'), this.props.collection);
-    }
+    // if (this.props.hasChanged) {
+    //   this.createBackup(this.props.entryDraft.get('entry'), this.props.collection);
+    // }
 
     if (prevProps.entry === this.props.entry) return;
 

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -328,12 +328,12 @@ export class Editor extends React.Component {
       return;
     }
 
-    removeAssets();
-    removeDraftEntryMediaFiles();
-
     await deleteUnpublishedEntry(collection.get('name'), slug);
 
     this.deleteBackup();
+
+    removeAssets();
+    removeDraftEntryMediaFiles();
 
     if (isModification) {
       loadEntry(collection, slug);

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -4,7 +4,7 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 import { Loader } from 'netlify-cms-ui-default';
 import { translate } from 'react-polyglot';
-import { debounce } from 'lodash';
+// import { debounce } from 'lodash';
 
 import { history, navigateToCollection, navigateToNewEntry } from '../../routing/history';
 import { logoutUser } from '../../actions/auth';
@@ -18,10 +18,10 @@ import {
   changeDraftFieldValidation,
   persistEntry,
   deleteEntry,
-  persistLocalBackup,
-  loadLocalBackup,
-  retrieveLocalBackup,
-  deleteLocalBackup,
+  // persistLocalBackup,
+  // loadLocalBackup,
+  // retrieveLocalBackup,
+  // deleteLocalBackup,
   removeDraftEntryMediaFiles,
 } from '../../actions/entries';
 import {
@@ -76,11 +76,11 @@ export class Editor extends React.Component {
     }),
     hasChanged: PropTypes.bool,
     t: PropTypes.func.isRequired,
-    retrieveLocalBackup: PropTypes.func.isRequired,
-    localBackup: ImmutablePropTypes.map,
-    loadLocalBackup: PropTypes.func,
-    persistLocalBackup: PropTypes.func.isRequired,
-    deleteLocalBackup: PropTypes.func,
+    // retrieveLocalBackup: PropTypes.func.isRequired,
+    // localBackup: ImmutablePropTypes.map,
+    // loadLocalBackup: PropTypes.func,
+    // persistLocalBackup: PropTypes.func.isRequired,
+    // deleteLocalBackup: PropTypes.func,
   };
 
   componentDidMount() {
@@ -91,12 +91,12 @@ export class Editor extends React.Component {
       loadEntry,
       createEmptyDraft,
       loadEntries,
-      retrieveLocalBackup,
+      // retrieveLocalBackup,
       collectionEntriesLoaded,
       t,
     } = this.props;
 
-    retrieveLocalBackup(collection, slug);
+    // retrieveLocalBackup(collection, slug);
 
     if (newEntry) {
       createEmptyDraft(collection, this.props.location.search);
@@ -154,7 +154,7 @@ export class Editor extends React.Component {
         return;
       }
 
-      this.deleteBackup();
+      // this.deleteBackup();
 
       unblock();
       this.unlisten();
@@ -189,7 +189,7 @@ export class Editor extends React.Component {
   }
 
   componentWillUnmount() {
-    this.createBackup.flush();
+    // this.createBackup.flush();
     this.props.discardDraft();
     if (this.props.hasChanged) {
       this.props.removeAssets();
@@ -197,9 +197,9 @@ export class Editor extends React.Component {
     window.removeEventListener('beforeunload', this.exitBlocker);
   }
 
-  createBackup = debounce(function (entry, collection) {
-    this.props.persistLocalBackup(entry, collection);
-  }, 2000);
+  // createBackup = debounce(function (entry, collection) {
+  //   this.props.persistLocalBackup(entry, collection);
+  // }, 2000);
 
   handleChangeDraftField = (field, value, metadata, i18n) => {
     const entries = [this.props.unPublishedEntry, this.props.publishedEntry].filter(Boolean);
@@ -217,11 +217,11 @@ export class Editor extends React.Component {
     updateUnpublishedEntryStatus(collection.get('name'), slug, currentStatus, newStatus);
   };
 
-  deleteBackup() {
-    const { deleteLocalBackup, collection, slug, newEntry } = this.props;
-    this.createBackup.cancel();
-    deleteLocalBackup(collection, !newEntry && slug);
-  }
+  // deleteBackup() {
+  //   const { deleteLocalBackup, collection, slug, newEntry } = this.props;
+  //   this.createBackup.cancel();
+  //   deleteLocalBackup(collection, !newEntry && slug);
+  // }
 
   handlePersistEntry = async (opts = {}) => {
     const { createNew = false, duplicate = false } = opts;
@@ -238,7 +238,7 @@ export class Editor extends React.Component {
 
     await persistEntry(collection);
 
-    this.deleteBackup();
+    // this.deleteBackup();
 
     if (createNew) {
       navigateToNewEntry(collection.get('name'));
@@ -249,10 +249,10 @@ export class Editor extends React.Component {
   };
 
   handlePublishEntry = async (opts = {}) => {
-    const { createNew = false, duplicate = false } = opts;
+    const { publishMain = false } = opts;
+
     const {
       publishUnpublishedEntry,
-      createDraftDuplicateFromEntry,
       entryDraft,
       collection,
       slug,
@@ -269,15 +269,7 @@ export class Editor extends React.Component {
       return;
     }
 
-    await publishUnpublishedEntry(collection.get('name'), slug);
-
-    this.deleteBackup();
-
-    if (createNew) {
-      navigateToNewEntry(collection.get('name'));
-    }
-
-    duplicate && createDraftDuplicateFromEntry(entryDraft.get('entry'));
+    await publishUnpublishedEntry(collection.get('name'), slug, publishMain);
   };
 
   handleUnpublishEntry = async () => {
@@ -311,7 +303,7 @@ export class Editor extends React.Component {
 
     setTimeout(async () => {
       await deleteEntry(collection, slug);
-      this.deleteBackup();
+      // this.deleteBackup();
       return navigateToCollection(collection.get('name'));
     }, 0);
   };
@@ -330,7 +322,7 @@ export class Editor extends React.Component {
 
     await deleteUnpublishedEntry(collection.get('name'), slug);
 
-    this.deleteBackup();
+    // this.deleteBackup();
 
     removeAssets();
     removeDraftEntryMediaFiles();
@@ -365,6 +357,7 @@ export class Editor extends React.Component {
       slug,
       t,
       editorBackLink,
+      canStack,
     } = this.props;
 
     const isPublished = !newEntry && !unpublishedEntry;
@@ -414,6 +407,7 @@ export class Editor extends React.Component {
         deployPreview={deployPreview}
         loadDeployPreview={opts => loadDeployPreview(collection, slug, entry, isPublished, opts)}
         editorBackLink={editorBackLink}
+        canStack={canStack}
         t={t}
       />
     );
@@ -421,7 +415,7 @@ export class Editor extends React.Component {
 }
 
 function mapStateToProps(state, ownProps) {
-  const { collections, entryDraft, auth, config, entries, globalUI } = state;
+  const { collections, entryDraft, auth, config, entries, globalUI, main } = state;
   const slug = ownProps.match.params[0];
   const collection = collections.get(ownProps.match.params.name);
   const collectionName = collection.get('name');
@@ -439,7 +433,7 @@ function mapStateToProps(state, ownProps) {
   const publishedEntry = selectEntry(state, collectionName, slug);
   const currentStatus = unPublishedEntry && unPublishedEntry.get('status');
   const deployPreview = selectDeployPreview(state, collectionName, slug);
-  const localBackup = entryDraft.get('localBackup');
+  // const localBackup = entryDraft.get('localBackup');
   const draftKey = entryDraft.get('key');
   let editorBackLink = `/collections/${collectionName}`;
   if (new URLSearchParams(ownProps.location.search).get('ref') === 'workflow') {
@@ -452,6 +446,8 @@ function mapStateToProps(state, ownProps) {
       editorBackLink = `${editorBackLink}/filter/${pathParts.slice(0, -2).join('/')}`;
     }
   }
+
+  const canStack = main.canStack;
 
   return {
     collection,
@@ -470,11 +466,12 @@ function mapStateToProps(state, ownProps) {
     collectionEntriesLoaded,
     currentStatus,
     deployPreview,
-    localBackup,
+    // localBackup,
     draftKey,
     publishedEntry,
     unPublishedEntry,
     editorBackLink,
+    canStack,
   };
 }
 
@@ -484,10 +481,10 @@ const mapDispatchToProps = {
   loadEntry,
   loadEntries,
   loadDeployPreview,
-  loadLocalBackup,
-  retrieveLocalBackup,
-  persistLocalBackup,
-  deleteLocalBackup,
+  // loadLocalBackup,
+  // retrieveLocalBackup,
+  // persistLocalBackup,
+  // deleteLocalBackup,
   createDraftDuplicateFromEntry,
   createEmptyDraft,
   discardDraft,

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -238,8 +238,8 @@ class EditorInterface extends Component {
 
     const previewEnabled = isPreviewEnabled(collection, entry);
 
-    const collectionI18nEnabled = hasI18n(collection);
     const { locales, defaultLocale } = getI18nInfo(this.props.collection);
+    const collectionI18nEnabled = hasI18n(collection) && locales.length > 1;
     const editorProps = {
       collection,
       entry,

--- a/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorInterface.js
@@ -173,10 +173,10 @@ class EditorInterface extends Component {
   };
 
   handleOnPublish = async (opts = {}) => {
-    const { createNew = false, duplicate = false } = opts;
+    const { createNew = false, duplicate = false, publishMain = false } = opts;
     await this.controlPaneRef.switchToDefaultLocale();
     this.controlPaneRef.validate();
-    this.props.onPublish({ createNew, duplicate });
+    this.props.onPublish({ createNew, duplicate, publishMain });
   };
 
   handleTogglePreview = () => {
@@ -231,6 +231,7 @@ class EditorInterface extends Component {
       deployPreview,
       draftKey,
       editorBackLink,
+      canStack,
       t,
     } = this.props;
 
@@ -335,6 +336,7 @@ class EditorInterface extends Component {
           onDeleteUnpublishedChanges={onDeleteUnpublishedChanges}
           onChangeStatus={onChangeStatus}
           showDelete={showDelete}
+          onPublishMain={() => this.handleOnPublish({ publishMain: true })}
           onPublish={onPublish}
           unPublish={unPublish}
           onDuplicate={onDuplicate}
@@ -354,6 +356,7 @@ class EditorInterface extends Component {
           loadDeployPreview={loadDeployPreview}
           deployPreview={deployPreview}
           editorBackLink={editorBackLink}
+          canStack={canStack}
         />
         <Editor key={draftKey}>
           <ViewControls>
@@ -428,6 +431,7 @@ EditorInterface.propTypes = {
   deployPreview: PropTypes.object,
   loadDeployPreview: PropTypes.func.isRequired,
   draftKey: PropTypes.string.isRequired,
+  canStack: PropTypes.string.isRequired,
   t: PropTypes.func.isRequired,
 };
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorToolbar.js
@@ -257,6 +257,7 @@ export class EditorToolbar extends React.Component {
     onDelete: PropTypes.func.isRequired,
     onDeleteUnpublishedChanges: PropTypes.func.isRequired,
     onChangeStatus: PropTypes.func.isRequired,
+    onPublishMain: PropTypes.func.isRequired,
     onPublish: PropTypes.func.isRequired,
     unPublish: PropTypes.func.isRequired,
     onDuplicate: PropTypes.func.isRequired,
@@ -403,8 +404,8 @@ export class EditorToolbar extends React.Component {
     );
   };
 
-  renderNewEntryWorkflowPublishControls = ({ canCreate, canPublish }) => {
-    const { isPublishing, onPublish, onPublishAndNew, onPublishAndDuplicate, t } = this.props;
+  renderNewEntryWorkflowPublishControls = ({ canPublish }) => {
+    const { isPublishing, onPublish, onPublishMain, canStack, t } = this.props;
 
     return canPublish ? (
       <ToolbarDropdown
@@ -422,9 +423,16 @@ export class EditorToolbar extends React.Component {
           label={t('editor.editorToolbar.publishNow')}
           icon="arrow"
           iconDirection="right"
-          onClick={onPublish}
+          onClick={onPublishMain}
         />
-        {canCreate ? (
+        {canStack && (
+          <DropdownItem
+            label={t('editor.editorToolbar.stackChange')}
+            icon="add"
+            onClick={onPublish}
+          />
+        )}
+        {/* {canCreate ? (
           <>
             <PublishDropDownItem
               label={t('editor.editorToolbar.publishAndCreateNew')}
@@ -437,7 +445,7 @@ export class EditorToolbar extends React.Component {
               onClick={onPublishAndDuplicate}
             />
           </>
-        ) : null}
+        ) : null} */}
       </ToolbarDropdown>
     ) : (
       ''
@@ -574,14 +582,15 @@ export class EditorToolbar extends React.Component {
     const canPublish = collection.get('publish') && !useOpenAuthoring;
     const canDelete = collection.get('delete', true);
 
-    const deleteLabel =
-      (hasUnpublishedChanges &&
-        isModification &&
-        t('editor.editorToolbar.deleteUnpublishedChanges')) ||
-      (hasUnpublishedChanges &&
-        (isNewEntry || !isModification) &&
-        t('editor.editorToolbar.deleteUnpublishedEntry')) ||
-      (!hasUnpublishedChanges && !isModification && t('editor.editorToolbar.deletePublishedEntry'));
+    const deleteLabel = t('editor.editorToolbar.discardChanges');
+    // const deleteLabel =
+    //   (hasUnpublishedChanges &&
+    //     isModification &&
+    //     t('editor.editorToolbar.deleteUnpublishedChanges')) ||
+    //   (hasUnpublishedChanges &&
+    //     (isNewEntry || !isModification) &&
+    //     t('editor.editorToolbar.deleteUnpublishedEntry')) ||
+    //   (!hasUnpublishedChanges && !isModification && t('editor.editorToolbar.deletePublishedEntry'));
 
     return [
       <SaveButton
@@ -593,17 +602,18 @@ export class EditorToolbar extends React.Component {
       </SaveButton>,
       currentStatus
         ? [
-            this.renderWorkflowStatusControls(),
-            this.renderNewEntryWorkflowPublishControls({ canCreate, canPublish }),
-          ]
+          this.renderWorkflowStatusControls(),
+          currentStatus === status.get('PENDING_PUBLISH') &&
+          this.renderNewEntryWorkflowPublishControls({ canCreate, canPublish }),
+        ]
         : !isNewEntry &&
-          this.renderExistingEntryWorkflowPublishControls({ canCreate, canPublish, canDelete }),
+        this.renderExistingEntryWorkflowPublishControls({ canCreate, canPublish, canDelete }),
       (!showDelete || useOpenAuthoring) && !hasUnpublishedChanges && !isModification ? null : (
         <DeleteButton
           key="delete-button"
           onClick={hasUnpublishedChanges ? onDeleteUnpublishedChanges : onDelete}
         >
-          {isDeleting ? t('editor.editorToolbar.deleting') : deleteLabel}
+          {isDeleting ? t('editor.editorToolbar.discarding') : deleteLabel}
         </DeleteButton>
       ),
     ];
@@ -658,9 +668,9 @@ export class EditorToolbar extends React.Component {
             {hasWorkflow ? this.renderWorkflowControls() : this.renderSimpleControls()}
           </ToolbarSubSectionFirst>
           <ToolbarSubSectionLast>
-            {hasWorkflow
+            {/* {hasWorkflow
               ? this.renderWorkflowDeployPreviewControls()
-              : this.renderSimpleDeployPreviewControls()}
+              : this.renderSimpleDeployPreviewControls()} */}
           </ToolbarSubSectionLast>
         </ToolbarSectionMain>
         <ToolbarSectionMeta>

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -184,9 +184,15 @@ class MediaLibrary extends React.Component {
     const files = [...fileList];
     let file = files[0];
 
+    const fileNamePattern = field.get('file_name_pattern');
+    if (fileNamePattern && !(new RegExp(fileNamePattern).test(file.name))) {
+      window.alert(`The name of the file must be with this pattern:\n\n${fileNamePattern.split('\\')[0]}\n\nPlease rename the file with a correct file name in order to continue.`);
+      return;
+    }
+
     const fileName = value && basename(value);
     if (fileName && fileName !== file.name) {
-      if (!window.confirm(`The name of the file must be ${fileName}. Do you want to make the name replacement?`)) {
+      if (!window.confirm(`The name of the file must be ${fileName}.\n\nDo you want to make the name replacement?`)) {
         return;
       }
       file = this.renameFile(file, fileName);

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -266,11 +266,7 @@ class MediaLibrary extends React.Component {
           if (currentRoundAspectRatio !== fileRoundAspectRatio) {
             const currentAspectRatio = this.getAspectRatio(existingImage.width, existingImage.height);
             const fileAspectRatio = this.getAspectRatio(fileImage.width, fileImage.height);
-            if (!window.confirm(
-              `${file.name} should have an aspect ratio of ${currentAspectRatio} but the image has an aspect ratio of ${fileAspectRatio}. Do you want to continue?`
-            )) {
-              return;
-            }
+            return window.alert(`${file.name} should have an aspect ratio of ${currentAspectRatio} but the image has an aspect ratio of ${fileAspectRatio}.`);
           }
         }
       }

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -5,10 +5,9 @@ import { connect } from 'react-redux';
 import { orderBy, map } from 'lodash';
 import { translate } from 'react-polyglot';
 import fuzzy from 'fuzzy';
-import { fileExtension } from 'netlify-cms-lib-util';
+import { basename, fileExtension } from 'netlify-cms-lib-util';
 
 import {
-  checkMedia as checkMediaAction,
   loadMedia as loadMediaAction,
   persistMedia as persistMediaAction,
   deleteMedia as deleteMediaAction,
@@ -46,6 +45,7 @@ class MediaLibrary extends React.Component {
     dynamicSearch: PropTypes.bool,
     dynamicSearchActive: PropTypes.bool,
     forImage: PropTypes.bool,
+    value: PropTypes.string,
     isLoading: PropTypes.bool,
     isPersisting: PropTypes.bool,
     isDeleting: PropTypes.bool,
@@ -179,12 +179,12 @@ class MediaLibrary extends React.Component {
     event.persist();
     event.stopPropagation();
     event.preventDefault();
-    const { persistMedia, privateUpload, config, t, field } = this.props;
+    const { persistMedia, privateUpload, config, t, field, value } = this.props;
     const { files: fileList } = event.dataTransfer || event.target;
     const files = [...fileList];
     let file = files[0];
 
-    const fileName = field.get('file_name');
+    const fileName = value && basename(value);
     if (fileName && fileName !== file.name) {
       if (!window.confirm(`The name of the file must be ${fileName}. Do you want to make the name replacement?`)) {
         return;
@@ -218,11 +218,9 @@ class MediaLibrary extends React.Component {
   handleInsert = () => {
     const { selectedFile } = this.state;
     const { path } = selectedFile;
-    const { checkMedia, insertMedia, field } = this.props;
-    if (checkMedia(path, field)) {
-      insertMedia(path, field);
-      this.handleClose();
-    }
+    const { insertMedia, field } = this.props;
+    insertMedia(path, field);
+    this.handleClose();
   };
 
   /**
@@ -327,6 +325,7 @@ class MediaLibrary extends React.Component {
       dynamicSearch,
       dynamicSearchActive,
       forImage,
+      value,
       isLoading,
       isPersisting,
       isDeleting,
@@ -345,6 +344,7 @@ class MediaLibrary extends React.Component {
         dynamicSearch={dynamicSearch}
         dynamicSearchActive={dynamicSearchActive}
         forImage={forImage}
+        value={value}
         isLoading={isLoading}
         isPersisting={isPersisting}
         isDeleting={isDeleting}
@@ -386,6 +386,7 @@ function mapStateToProps(state) {
     dynamicSearchActive: mediaLibrary.get('dynamicSearchActive'),
     dynamicSearchQuery: mediaLibrary.get('dynamicSearchQuery'),
     forImage: mediaLibrary.get('forImage'),
+    value: mediaLibrary.get('value'),
     isLoading: mediaLibrary.get('isLoading'),
     isPersisting: mediaLibrary.get('isPersisting'),
     isDeleting: mediaLibrary.get('isDeleting'),
@@ -400,7 +401,6 @@ function mapStateToProps(state) {
 }
 
 const mapDispatchToProps = {
-  checkMedia: checkMediaAction,
   loadMedia: loadMediaAction,
   persistMedia: persistMediaAction,
   deleteMedia: deleteMediaAction,

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -215,6 +215,24 @@ class MediaLibrary extends React.Component {
       );
     }
 
+    const keepFileName = validation.get('keep_file_name');
+    if (keepFileName && value) {
+      const isFile = file instanceof File;
+      if (isFile) {
+        const valueName = basename(value);
+        const fileModuleName = valueName.replace(/^([^_]*).*/, "$1_");
+        const fileNameRegex = new RegExp(`^${fileModuleName}`);
+        if (!fileNameRegex.test(file.name)) {
+          return window.alert(
+            t('mediaLibrary.mediaLibrary.fileNamePatternError', {
+              pattern: `${fileModuleName}name`,
+            })
+          );
+
+        }
+      }
+    }
+
     const maxFileSize = validation.get('max_file_size');
     if (maxFileSize && file.size > maxFileSize * 100) {
       return window.alert(
@@ -278,24 +296,6 @@ class MediaLibrary extends React.Component {
 
       if (minHeight && fileImage.height < minHeight) {
         return window.alert(`${file.name} must have a min height of ${minHeight}.`)
-      }
-    }
-
-    const keepFileName = validation.get('keep_file_name');
-    if (keepFileName && value) {
-      const isFile = file instanceof File;
-      if (isFile) {
-        const valueName = basename(value);
-        const fileModuleName = valueName.replace(/^([^_]*).*/, "$1_");
-        const fileNameRegex = new RegExp(`^${fileModuleName}`);
-        if (!fileNameRegex.test(file.name)) {
-          return window.alert(
-            t('mediaLibrary.mediaLibrary.fileNamePatternError', {
-              pattern: `${fileModuleName}name`,
-            })
-          );
-
-        }
       }
     }
 

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -254,7 +254,7 @@ class MediaLibrary extends React.Component {
         }
       }
 
-      if (keepAspectRatio) {
+      if (keepAspectRatio && value) {
         const valueName = basename(value);
         const currentFile = currentFiles && currentFiles.find(findFile => findFile.name === valueName);
         if (currentFile) {

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -275,9 +275,7 @@ class MediaLibrary extends React.Component {
           const currentRoundAspectRatio = this.getRoundAspectRatio(existingImage.width, existingImage.height);
           const fileRoundAspectRatio = this.getRoundAspectRatio(fileImage.width, fileImage.height);
           if (currentRoundAspectRatio !== fileRoundAspectRatio) {
-            const currentAspectRatio = this.getAspectRatio(existingImage.width, existingImage.height);
-            const fileAspectRatio = this.getAspectRatio(fileImage.width, fileImage.height);
-            return window.alert(`${file.name} should have an aspect ratio of ${currentAspectRatio} but the image has an aspect ratio of ${fileAspectRatio}.`);
+            return window.alert(`${file.name} should have a size of ${existingImage.width}x${existingImage.height} the current size is ${fileImage.width}x${fileImage.height}.`);
           }
         }
       }

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibrary.js
@@ -178,13 +178,6 @@ class MediaLibrary extends React.Component {
     return Math.round(ratio * 10) / 10;
   }
 
-  renameFile = (originalFile, newName) => {
-    return new File([originalFile], newName, {
-      type: originalFile.type,
-      lastModified: originalFile.lastModified,
-    });
-  }
-
   getDisplayURL = (file) => {
     if (!file) return
 
@@ -293,21 +286,15 @@ class MediaLibrary extends React.Component {
       const isFile = file instanceof File;
       if (isFile) {
         const valueName = basename(value);
-        const valueExtension = fileExtension(value);
-        if (valueName !== file.name) {
-          if (valueExtension === fileExtension(file.name)) {
-            if (!window.confirm(
-              t('mediaLibrary.mediaLibrary.fileNameCheckReplacement', {
-                fileName: valueName,
-              }),)) {
-              return;
-            }
-            return this.renameFile(file, valueName);
-          }
+        const fileModuleName = valueName.replace(/^([^_]*).*/, "$1_");
+        const fileNameRegex = new RegExp(`^${fileModuleName}`);
+        if (!fileNameRegex.test(file.name)) {
           return window.alert(
             t('mediaLibrary.mediaLibrary.fileNamePatternError', {
-              pattern: valueName,
-            }),)
+              pattern: `${fileModuleName}name`,
+            })
+          );
+
         }
       }
     }

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
@@ -67,6 +67,7 @@ function MediaLibraryModal({
   files,
   dynamicSearch,
   dynamicSearchActive,
+  fileExtensions,
   forImage,
   value,
   isLoading,
@@ -78,6 +79,7 @@ function MediaLibraryModal({
   query,
   selectedFile,
   handleFilter,
+  handleImageFilter,
   handleQuery,
   toTableData,
   handleClose,
@@ -94,7 +96,7 @@ function MediaLibraryModal({
   displayURLs,
   t,
 }) {
-  const filteredFiles = forImage ? handleFilter(files) : files;
+  const filteredFiles = fileExtensions ? handleFilter(files, fileExtensions) : (forImage ? handleImageFilter(files) : files);
   const queriedFiles = !dynamicSearch && query ? handleQuery(query, filteredFiles) : filteredFiles;
   const tableData = toTableData(queriedFiles);
   const hasFiles = files && !!files.length;
@@ -132,6 +134,7 @@ function MediaLibraryModal({
         isPersisting={isPersisting}
         isDeleting={isDeleting}
         selectedFile={selectedFile}
+        fileExtensions={fileExtensions}
       />
       {!shouldShowEmptyMessage ? null : (
         <EmptyMessage content={emptyMessage} isPrivate={privateUpload} />
@@ -184,6 +187,7 @@ MediaLibraryModal.propTypes = {
   query: PropTypes.string,
   selectedFile: PropTypes.oneOfType([PropTypes.shape(fileShape), PropTypes.shape({})]),
   handleFilter: PropTypes.func.isRequired,
+  handleImageFilter: PropTypes.func.isRequired,
   handleQuery: PropTypes.func.isRequired,
   toTableData: PropTypes.func.isRequired,
   handleClose: PropTypes.func.isRequired,
@@ -196,8 +200,9 @@ MediaLibraryModal.propTypes = {
   handleAssetClick: PropTypes.func.isRequired,
   handleLoadMore: PropTypes.func.isRequired,
   loadDisplayURL: PropTypes.func.isRequired,
-  t: PropTypes.func.isRequired,
   displayURLs: PropTypes.instanceOf(Map).isRequired,
+  fileExtensions: PropTypes.arrayOf(PropTypes.string),
+  t: PropTypes.func.isRequired,
 };
 
 export default translate()(MediaLibraryModal);

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryModal.js
@@ -68,6 +68,7 @@ function MediaLibraryModal({
   dynamicSearch,
   dynamicSearchActive,
   forImage,
+  value,
   isLoading,
   isPersisting,
   isDeleting,
@@ -117,6 +118,7 @@ function MediaLibraryModal({
         onClose={handleClose}
         privateUpload={privateUpload}
         forImage={forImage}
+        value={value}
         onDownload={handleDownload}
         onUpload={handlePersist}
         query={query}
@@ -172,6 +174,7 @@ MediaLibraryModal.propTypes = {
   dynamicSearch: PropTypes.bool,
   dynamicSearchActive: PropTypes.bool,
   forImage: PropTypes.bool,
+  value: PropTypes.string,
   isLoading: PropTypes.bool,
   isPersisting: PropTypes.bool,
   isDeleting: PropTypes.bool,

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
@@ -6,7 +6,7 @@ import MediaLibrarySearch from './MediaLibrarySearch';
 import MediaLibraryHeader from './MediaLibraryHeader';
 import {
   UploadButton,
-  DeleteButton,
+  // DeleteButton,
   DownloadButton,
   CopyToClipBoardButton,
   InsertButton,
@@ -48,14 +48,14 @@ function MediaLibraryTop({
 }) {
   const shouldShowButtonLoader = isPersisting || isDeleting;
   const uploadEnabled = !shouldShowButtonLoader;
-  const deleteEnabled = !shouldShowButtonLoader && hasSelection;
+  // const deleteEnabled = !shouldShowButtonLoader && selectedFile.draft;
 
   const uploadButtonLabel = isPersisting
     ? t('mediaLibrary.mediaLibraryModal.uploading')
     : t('mediaLibrary.mediaLibraryModal.upload');
-  const deleteButtonLabel = isDeleting
-    ? t('mediaLibrary.mediaLibraryModal.deleting')
-    : t('mediaLibrary.mediaLibraryModal.deleteSelected');
+  // const deleteButtonLabel = isDeleting
+  //   ? t('mediaLibrary.mediaLibraryModal.deleting')
+  //   : t('mediaLibrary.mediaLibraryModal.deleteSelected');
   const downloadButtonLabel = t('mediaLibrary.mediaLibraryModal.download');
   const insertButtonLabel = t('mediaLibrary.mediaLibraryModal.chooseSelected');
 
@@ -99,9 +99,9 @@ function MediaLibraryTop({
           disabled={searchDisabled}
         />
         <ButtonsContainer>
-          <DeleteButton onClick={onDelete} disabled={!deleteEnabled}>
+          {/* <DeleteButton onClick={onDelete} disabled={!deleteEnabled}>
             {deleteButtonLabel}
-          </DeleteButton>
+          </DeleteButton> */}
           {!canInsert ? null : (
             <InsertButton onClick={onInsert} disabled={!hasSelection}>
               {insertButtonLabel}

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
-import { basename } from 'netlify-cms-lib-util';
 
 import MediaLibrarySearch from './MediaLibrarySearch';
 import MediaLibraryHeader from './MediaLibraryHeader';
@@ -33,7 +32,6 @@ function MediaLibraryTop({
   onClose,
   privateUpload,
   forImage,
-  value,
   onDownload,
   onUpload,
   query,
@@ -47,11 +45,12 @@ function MediaLibraryTop({
   isPersisting,
   isDeleting,
   selectedFile,
+  fileExtensions,
 }) {
-  const isNewOrReplacement = !value || selectedFile.draft && selectedFile.name === basename(value);
   const shouldShowButtonLoader = isPersisting || isDeleting;
   const uploadEnabled = !shouldShowButtonLoader;
-  const chooseEnabled = hasSelection && isNewOrReplacement;
+
+  const acceptFiles = fileExtensions && fileExtensions.map(extension => `.${extension}`).join();
 
   const uploadButtonLabel = isPersisting
     ? t('mediaLibrary.mediaLibraryModal.uploading')
@@ -68,8 +67,8 @@ function MediaLibraryTop({
         <MediaLibraryHeader
           onClose={onClose}
           title={`${privateUpload ? t('mediaLibrary.mediaLibraryModal.private') : ''}${forImage
-              ? t('mediaLibrary.mediaLibraryModal.images')
-              : t('mediaLibrary.mediaLibraryModal.mediaAssets')
+            ? t('mediaLibrary.mediaLibraryModal.images')
+            : t('mediaLibrary.mediaLibraryModal.mediaAssets')
             }`}
           isPrivate={privateUpload}
         />
@@ -85,12 +84,13 @@ function MediaLibraryTop({
             {downloadButtonLabel}
           </DownloadButton>
           {!canInsert ? null : (
-              <UploadButton
-            label={uploadButtonLabel}
-            imagesOnly={forImage}
-            onChange={onUpload}
-            disabled={!uploadEnabled}
-          />
+            <UploadButton
+              label={uploadButtonLabel}
+              acceptFiles={acceptFiles}
+              imagesOnly={forImage}
+              onChange={onUpload}
+              disabled={!uploadEnabled}
+            />
           )}
         </ButtonsContainer>
       </RowContainer>
@@ -107,7 +107,7 @@ function MediaLibraryTop({
             {deleteButtonLabel}
           </DeleteButton> */}
           {!canInsert ? null : (
-            <InsertButton onClick={onInsert} disabled={!chooseEnabled}>
+            <InsertButton onClick={onInsert} disabled={!hasSelection}>
               {insertButtonLabel}
             </InsertButton>
           )}
@@ -143,6 +143,7 @@ MediaLibraryTop.propTypes = {
     }),
     PropTypes.shape({}),
   ]),
+  fileExtensions: PropTypes.arrayOf(PropTypes.string),
 };
 
 export default MediaLibraryTop;

--- a/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
+++ b/packages/netlify-cms-core/src/components/MediaLibrary/MediaLibraryTop.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import styled from '@emotion/styled';
+import { basename } from 'netlify-cms-lib-util';
 
 import MediaLibrarySearch from './MediaLibrarySearch';
 import MediaLibraryHeader from './MediaLibraryHeader';
@@ -32,13 +33,14 @@ function MediaLibraryTop({
   onClose,
   privateUpload,
   forImage,
+  value,
   onDownload,
   onUpload,
   query,
   onSearchChange,
   onSearchKeyDown,
   searchDisabled,
-  onDelete,
+  // onDelete,
   canInsert,
   onInsert,
   hasSelection,
@@ -46,9 +48,10 @@ function MediaLibraryTop({
   isDeleting,
   selectedFile,
 }) {
+  const isNewOrReplacement = !value || selectedFile.draft && selectedFile.name === basename(value);
   const shouldShowButtonLoader = isPersisting || isDeleting;
   const uploadEnabled = !shouldShowButtonLoader;
-  // const deleteEnabled = !shouldShowButtonLoader && selectedFile.draft;
+  const chooseEnabled = hasSelection && isNewOrReplacement;
 
   const uploadButtonLabel = isPersisting
     ? t('mediaLibrary.mediaLibraryModal.uploading')
@@ -64,11 +67,10 @@ function MediaLibraryTop({
       <RowContainer>
         <MediaLibraryHeader
           onClose={onClose}
-          title={`${privateUpload ? t('mediaLibrary.mediaLibraryModal.private') : ''}${
-            forImage
+          title={`${privateUpload ? t('mediaLibrary.mediaLibraryModal.private') : ''}${forImage
               ? t('mediaLibrary.mediaLibraryModal.images')
               : t('mediaLibrary.mediaLibraryModal.mediaAssets')
-          }`}
+            }`}
           isPrivate={privateUpload}
         />
         <ButtonsContainer>
@@ -82,12 +84,14 @@ function MediaLibraryTop({
           <DownloadButton onClick={onDownload} disabled={!hasSelection}>
             {downloadButtonLabel}
           </DownloadButton>
-          <UploadButton
+          {!canInsert ? null : (
+              <UploadButton
             label={uploadButtonLabel}
             imagesOnly={forImage}
             onChange={onUpload}
             disabled={!uploadEnabled}
           />
+          )}
         </ButtonsContainer>
       </RowContainer>
       <RowContainer>
@@ -103,7 +107,7 @@ function MediaLibraryTop({
             {deleteButtonLabel}
           </DeleteButton> */}
           {!canInsert ? null : (
-            <InsertButton onClick={onInsert} disabled={!hasSelection}>
+            <InsertButton onClick={onInsert} disabled={!chooseEnabled}>
               {insertButtonLabel}
             </InsertButton>
           )}
@@ -118,13 +122,14 @@ MediaLibraryTop.propTypes = {
   onClose: PropTypes.func.isRequired,
   privateUpload: PropTypes.bool,
   forImage: PropTypes.bool,
+  value: PropTypes.string,
   onDownload: PropTypes.func.isRequired,
   onUpload: PropTypes.func.isRequired,
   query: PropTypes.string,
   onSearchChange: PropTypes.func.isRequired,
   onSearchKeyDown: PropTypes.func.isRequired,
   searchDisabled: PropTypes.bool.isRequired,
-  onDelete: PropTypes.func.isRequired,
+  // onDelete: PropTypes.func.isRequired,
   canInsert: PropTypes.bool,
   onInsert: PropTypes.func.isRequired,
   hasSelection: PropTypes.bool.isRequired,

--- a/packages/netlify-cms-core/src/components/UI/FileUploadButton.js
+++ b/packages/netlify-cms-core/src/components/UI/FileUploadButton.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-export function FileUploadButton({ label, imagesOnly, onChange, disabled, className }) {
+export function FileUploadButton({ label, acceptFiles, imagesOnly, onChange, disabled, className }) {
   return (
     <label tabIndex={'0'} className={`nc-fileUploadButton ${className || ''}`}>
       <span>{label}</span>
       <input
         type="file"
-        accept={imagesOnly ? 'image/*' : '*/*'}
+        accept={acceptFiles || (imagesOnly ? 'image/*' : '*/*')}
         onChange={onChange}
         disabled={disabled}
       />
@@ -18,6 +18,7 @@ export function FileUploadButton({ label, imagesOnly, onChange, disabled, classN
 FileUploadButton.propTypes = {
   className: PropTypes.string,
   label: PropTypes.string.isRequired,
+  acceptFiles: PropTypes.string,
   imagesOnly: PropTypes.bool,
   onChange: PropTypes.func.isRequired,
   disabled: PropTypes.bool,

--- a/packages/netlify-cms-core/src/constants/__tests__/configSchema.spec.js
+++ b/packages/netlify-cms-core/src/constants/__tests__/configSchema.spec.js
@@ -494,6 +494,19 @@ describe('config', () => {
         }).toThrowError(`'i18n.locales[1]' must NOT have more than 10 characters`);
       });
 
+      it('should throw error when locales is less than 1 items', () => {
+        expect(() => {
+          validateConfig(
+            merge({}, validConfig, {
+              i18n: {
+                structure: 'multiple_folders',
+                locales: [],
+              },
+            }),
+          );
+        }).toThrowError(`'i18n.locales' must NOT have fewer than 1 items`);
+      });
+
       it('should allow valid locales strings', () => {
         expect(() => {
           validateConfig(

--- a/packages/netlify-cms-core/src/constants/configSchema.js
+++ b/packages/netlify-cms-core/src/constants/configSchema.js
@@ -20,7 +20,7 @@ const i18n = {
     structure: { type: 'string', enum: Object.values(I18N_STRUCTURE) },
     locales: {
       type: 'array',
-      minItems: 2,
+      minItems: 1,
       items: localeType,
       uniqueItems: true,
     },

--- a/packages/netlify-cms-core/src/formats/formats.ts
+++ b/packages/netlify-cms-core/src/formats/formats.ts
@@ -5,7 +5,9 @@ import yamlFormatter from './yaml';
 import tomlFormatter from './toml';
 import jsonFormatter from './json';
 import { FrontmatterInfer, frontmatterJSON, frontmatterTOML, frontmatterYAML } from './frontmatter';
+import { prettierJSON, prettierTOML, prettierYAML } from './prettier';
 
+import type { Options as PrettierOptions } from 'prettier';
 import type { Delimiter } from './frontmatter';
 import type { Collection, EntryObject, Format } from '../types/redux';
 import type { EntryValue } from '../valueObjects/Entry';
@@ -18,9 +20,12 @@ export const formatExtensions = {
   toml: 'toml',
   json: 'json',
   frontmatter: 'md',
-  'json-frontmatter': 'md',
-  'toml-frontmatter': 'md',
   'yaml-frontmatter': 'md',
+  'toml-frontmatter': 'md',
+  'json-frontmatter': 'md',
+  'yaml-prettier': 'yml',
+  'toml-prettier': 'toml',
+  'json-prettier': 'json',
 };
 
 export const extensionFormatters = {
@@ -30,19 +35,24 @@ export const extensionFormatters = {
   json: jsonFormatter,
   md: FrontmatterInfer,
   markdown: FrontmatterInfer,
-  html: FrontmatterInfer,
 };
 
-function formatByName(name: Format, customDelimiter?: Delimiter) {
+function formatByName(
+  name: Format,
+  { customDelimiter, prettierOptions }: { customDelimiter?: Delimiter; prettierOptions?: PrettierOptions },
+) {
   return {
     yml: yamlFormatter,
     yaml: yamlFormatter,
     toml: tomlFormatter,
     json: jsonFormatter,
     frontmatter: FrontmatterInfer,
-    'json-frontmatter': frontmatterJSON(customDelimiter),
-    'toml-frontmatter': frontmatterTOML(customDelimiter),
     'yaml-frontmatter': frontmatterYAML(customDelimiter),
+    'toml-frontmatter': frontmatterTOML(customDelimiter),
+    'json-frontmatter': frontmatterJSON(customDelimiter),
+    'yaml-prettier': prettierYAML(prettierOptions),
+    'toml-prettier': prettierTOML(prettierOptions),
+    'json-prettier': prettierJSON(prettierOptions),
   }[name];
 }
 
@@ -58,11 +68,12 @@ export function resolveFormat(collection: Collection, entry: EntryObject | Entry
   const customDelimiter = frontmatterDelimiterIsList(frontmatter_delimiter)
     ? (frontmatter_delimiter.toArray() as [string, string])
     : frontmatter_delimiter;
+  const prettierOptions = collection.get('prettier')?.toJS();
 
   // If the format is specified in the collection, use that format.
   const formatSpecification = collection.get('format');
   if (formatSpecification) {
-    return formatByName(formatSpecification, customDelimiter);
+    return formatByName(formatSpecification, { customDelimiter, prettierOptions });
   }
 
   // If a file already exists, infer the format from its file extension.
@@ -82,5 +93,5 @@ export function resolveFormat(collection: Collection, entry: EntryObject | Entry
   }
 
   // If no format is specified and it cannot be inferred, return the default.
-  return formatByName('frontmatter', customDelimiter);
+  return formatByName('frontmatter', { customDelimiter, prettierOptions });
 }

--- a/packages/netlify-cms-core/src/formats/prettier.ts
+++ b/packages/netlify-cms-core/src/formats/prettier.ts
@@ -1,0 +1,68 @@
+import prettier from 'prettier/standalone';
+import parserYaml from 'prettier/parser-yaml';
+import parserMarkdown from 'prettier/parser-markdown';
+
+import yamlFormatter from './yaml';
+import tomlFormatter from './toml';
+import jsonFormatter from './json';
+
+import type { Options as PrettierOptions } from 'prettier';
+
+const Languages = {
+  YAML: 'yaml',
+  TOML: 'toml',
+  JSON: 'json',
+} as const;
+
+type Language = typeof Languages[keyof typeof Languages];
+
+const parsers = {
+  [Languages.YAML]: yamlFormatter,
+  [Languages.TOML]: tomlFormatter,
+  [Languages.JSON]: jsonFormatter,
+};
+
+type Format = typeof parsers[keyof typeof parsers];
+
+export class PrettierFormatter {
+  language: Language;
+  format: Format;
+  options?: PrettierOptions;
+
+  constructor(language: Language, options?: PrettierOptions) {
+    this.language = language;
+    this.format = parsers[language];
+    this.options = { parser: this.language, ...options };
+  }
+
+  fromFile(content: string) {
+    return this.format.fromFile(content);
+  }
+
+  toFile(
+    data: { body?: string } & Record<string, unknown>,
+    sortedKeys?: string[],
+    comments?: Record<string, string>,
+  ) {
+    const file = this.format.toFile(data, sortedKeys, comments);
+    return prettier.format(file, this.options);
+  }
+}
+
+export function prettierYAML(options?: PrettierOptions) {
+  return new PrettierFormatter(Languages.YAML, {
+    plugins: [parserYaml],
+    ...options,
+  });
+}
+
+export function prettierTOML(options?: PrettierOptions) {
+  return new PrettierFormatter(Languages.TOML, {
+    plugins: [parserMarkdown],
+    ...options,
+  });
+}
+
+export function prettierJSON(options?: PrettierOptions) {
+  return new PrettierFormatter(Languages.JSON, options);
+}

--- a/packages/netlify-cms-core/src/lib/consoleError.js
+++ b/packages/netlify-cms-core/src/lib/consoleError.js
@@ -1,7 +1,7 @@
 export default function consoleError(title, description) {
-  console.error(
+  console.warn(
     `%c ⛔ ${title}\n` + `%c${description}\n\n`,
-    'color: black; font-weight: bold; font-size: 16px; line-height: 50px;',
-    'color: black;',
+    'color: white; font-weight: bold; font-size: 16px; line-height: 50px;',
+    'color: white;',
   );
 }

--- a/packages/netlify-cms-core/src/lib/formatters.ts
+++ b/packages/netlify-cms-core/src/lib/formatters.ts
@@ -24,6 +24,7 @@ const {
 } = stringTemplate;
 
 const commitMessageTemplates = {
+  main: 'Batch update to {{main}}',
   create: 'Create {{collection}} “{{slug}}”',
   update: 'Update {{collection}} “{{slug}}”',
   delete: 'Delete {{collection}} “{{slug}}”',
@@ -35,6 +36,7 @@ const commitMessageTemplates = {
 const variableRegex = /\{\{([^}]+)\}\}/g;
 
 type Options = {
+  main?: string;
   slug?: string;
   path?: string;
   collection?: Collection;
@@ -45,13 +47,15 @@ type Options = {
 export function commitMessageFormatter(
   type: keyof typeof commitMessageTemplates,
   config: CmsConfig,
-  { slug, path, collection, authorLogin, authorName }: Options,
+  { main, slug, path, collection, authorLogin, authorName }: Options,
   isOpenAuthoring?: boolean,
 ) {
   const templates = { ...commitMessageTemplates, ...(config.backend.commit_messages || {}) };
 
   const commitMessage = templates[type].replace(variableRegex, (_, variable) => {
     switch (variable) {
+      case 'main':
+        return main || '';
       case 'slug':
         return slug || '';
       case 'path':

--- a/packages/netlify-cms-core/src/lib/i18n.ts
+++ b/packages/netlify-cms-core/src/lib/i18n.ts
@@ -420,7 +420,9 @@ export function serializeI18n(
     .filter(locale => locale !== defaultLocale)
     .forEach(locale => {
       const dataPath = getLocaleDataPath(locale);
-      entry = entry.setIn(dataPath, serializeValues(entry.getIn(dataPath)));
+      const data = entry.getIn(dataPath);
+      if (!data) return;
+      entry = entry.setIn(dataPath, serializeValues(data));
     });
 
   return entry;

--- a/packages/netlify-cms-core/src/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/mediaLibrary.ts
@@ -7,9 +7,9 @@ import { once } from 'lodash';
 import { getMediaLibrary } from './lib/registry';
 import { store } from './redux';
 import { configFailed } from './actions/config';
-import { createMediaLibrary, insertMedia } from './actions/mediaLibrary';
+import { createMediaLibrary, createMediaLibraryValidation, insertMedia } from './actions/mediaLibrary';
 
-import type { MediaLibraryInstance } from './types/redux';
+import type { MediaLibraryInstance, CmsMediaValidation } from './types/redux';
 
 type MediaLibraryOptions = {};
 
@@ -39,6 +39,10 @@ const initializeMediaLibrary = once(async function initializeMediaLibrary(name, 
   }
 });
 
+const initializeMediaValidation = once(async function initializeMediaValidation(validation: CmsMediaValidation) {
+  if (validation) return store.dispatch(createMediaLibraryValidation(validation));
+});
+
 store.subscribe(() => {
   const state = store.getState();
   if (state) {
@@ -46,6 +50,10 @@ store.subscribe(() => {
     if (mediaLibraryName && !state.mediaLibrary.get('externalLibrary')) {
       const mediaLibraryConfig = state.config.media_library;
       initializeMediaLibrary(mediaLibraryName, mediaLibraryConfig);
+    }
+    const mediaLibraryValidation = state.config.media_validation;
+    if (mediaLibraryValidation) {
+      initializeMediaValidation(mediaLibraryValidation);
     }
   }
 });

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -18,6 +18,7 @@ import {
   ENTRY_PERSIST_FAILURE,
   ENTRY_DELETE_SUCCESS,
   ADD_DRAFT_ENTRY_MEDIA_FILE,
+  REMOVE_DRAFT_ENTRY_MEDIA_FILES,
   REMOVE_DRAFT_ENTRY_MEDIA_FILE,
 } from '../actions/entries';
 import {
@@ -181,6 +182,18 @@ function entryDraftReducer(state = Map(), action) {
           mediaFiles
             .filterNot(file => file.get('id') === action.payload.id)
             .insert(0, fromJS(action.payload)),
+        );
+        state.set('hasChanged', true);
+      });
+    }
+
+    case REMOVE_DRAFT_ENTRY_MEDIA_FILES: {
+      return state.withMutations(state => {
+        const mediaFiles = state.getIn(['entry', 'mediaFiles']);
+
+        state.setIn(
+          ['entry', 'mediaFiles'],
+          mediaFiles.filterNot(file => file.get('draft')),
         );
         state.set('hasChanged', true);
       });

--- a/packages/netlify-cms-core/src/reducers/index.ts
+++ b/packages/netlify-cms-core/src/reducers/index.ts
@@ -13,6 +13,7 @@ import medias from './medias';
 import mediaLibrary from './mediaLibrary';
 import deploys, * as fromDeploys from './deploys';
 import globalUI from './globalUI';
+import main from './main';
 import status from './status';
 
 import type { Status } from '../constants/publishModes';
@@ -32,6 +33,7 @@ const reducers = {
   mediaLibrary,
   deploys,
   globalUI,
+  main,
   status,
 };
 

--- a/packages/netlify-cms-core/src/reducers/main.ts
+++ b/packages/netlify-cms-core/src/reducers/main.ts
@@ -1,0 +1,69 @@
+import { produce } from 'immer';
+
+import {
+  STATUS_MAIN_REQUEST,
+  STATUS_MAIN_SUCCESS,
+  STATUS_MAIN_FAILURE,
+  CLOSE_MAIN_REQUEST,
+  CLOSE_MAIN_SUCCESS,
+  CLOSE_MAIN_FAILURE,
+  PUBLISH_MAIN_REQUEST,
+  PUBLISH_MAIN_SUCCESS,
+  PUBLISH_MAIN_FAILURE,
+} from '../actions/main';
+
+import type { MainStatusAction } from '../actions/main';
+
+export type MainStatus = {
+  isFetching: boolean;
+  canStack: boolean;
+  status: {
+    status?: string;
+    updatedAt?: string;
+  };
+  error: Error | undefined;
+};
+
+const defaultState: MainStatus = {
+  isFetching: false,
+  canStack: false,
+  status: {},
+  error: undefined,
+};
+
+const status = produce((state: MainStatus, action: MainStatusAction) => {
+  switch (action.type) {
+    case STATUS_MAIN_REQUEST:
+      state.isFetching = true;
+      break;
+    case STATUS_MAIN_SUCCESS:
+      state.isFetching = false;
+      state.canStack = true;
+      state.status = action.payload.status;
+      break;
+    case STATUS_MAIN_FAILURE:
+      state.isFetching = false;
+      state.canStack = false;
+      state.error = action.payload.error;
+      break;
+    case PUBLISH_MAIN_REQUEST:
+      state.isFetching = true;
+      break;
+    case PUBLISH_MAIN_SUCCESS:
+      state.isFetching = false;
+      break;
+    case PUBLISH_MAIN_FAILURE:
+      state.isFetching = false;
+      break;
+    case CLOSE_MAIN_REQUEST:
+      state.isFetching = true;
+      break;
+    case CLOSE_MAIN_SUCCESS:
+      state.isFetching = false;
+      break;
+    case CLOSE_MAIN_FAILURE:
+      state.isFetching = false;
+  }
+}, defaultState);
+
+export default status;

--- a/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
@@ -49,7 +49,7 @@ const defaultState: {
   replaceIndex?: number;
 } = {
   isVisible: false,
-  showMediaButton: false,
+  showMediaButton: true,
   controlMedia: Map(),
   displayURLs: Map(),
   config: Map(),

--- a/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
@@ -51,7 +51,7 @@ const defaultState: {
   replaceIndex?: number;
 } = {
   isVisible: false,
-  showMediaButton: false,
+  showMediaButton: true,
   controlMedia: Map(),
   displayURLs: Map(),
   config: Map(),

--- a/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
@@ -6,6 +6,7 @@ import {
   MEDIA_LIBRARY_OPEN,
   MEDIA_LIBRARY_CLOSE,
   MEDIA_LIBRARY_CREATE,
+  MEDIA_LIBRARY_VALIDATION,
   MEDIA_INSERT,
   MEDIA_REMOVE_INSERTED,
   MEDIA_LOAD_REQUEST,
@@ -44,6 +45,7 @@ const defaultState: {
   page?: number;
   files?: MediaFile[];
   config: Map<string, unknown>;
+  validation?: Map<string, unknown>;
   field?: EntryField;
   value?: string | string[];
   replaceIndex?: number;
@@ -53,6 +55,7 @@ const defaultState: {
   controlMedia: Map(),
   displayURLs: Map(),
   config: Map(),
+  validation: Map(),
 };
 
 function mediaLibrary(state = Map(defaultState), action: MediaLibraryAction) {
@@ -63,10 +66,22 @@ function mediaLibrary(state = Map(defaultState), action: MediaLibraryAction) {
         map.set('showMediaButton', action.payload.enableStandalone());
       });
 
+    case MEDIA_LIBRARY_VALIDATION:
+      return state.withMutations(map => {
+        const { payload } = action;
+        const { images = {} } = action.payload;
+
+        map.set('validation', Map({
+          ...payload,
+          images: Map(images)
+        }));
+      });
+
     case MEDIA_LIBRARY_OPEN: {
-      const { controlID, forImage, privateUpload, config, field, value, replaceIndex } =
-        action.payload;
-      const libConfig = config || Map();
+      const { controlID, forImage, privateUpload, config = Map(), validation = Map(), field, value, replaceIndex } = action.payload;
+      const libConfig = config;
+      const mediaLibraryValidation = state.get('validation');
+      const mediaValidation = mediaLibraryValidation ? mediaLibraryValidation.mergeDeep(validation) : validation;
       const privateUploadChanged = state.get('privateUpload') !== privateUpload;
       if (privateUploadChanged) {
         return Map({
@@ -76,6 +91,7 @@ function mediaLibrary(state = Map(defaultState), action: MediaLibraryAction) {
           canInsert: !!controlID,
           privateUpload,
           config: libConfig,
+          validation: mediaValidation,
           controlMedia: Map(),
           displayURLs: Map(),
           field,
@@ -90,6 +106,7 @@ function mediaLibrary(state = Map(defaultState), action: MediaLibraryAction) {
         map.set('canInsert', !!controlID);
         map.set('privateUpload', privateUpload);
         map.set('config', libConfig);
+        map.set('validation', mediaValidation);
         map.set('field', field);
         map.set('value', value);
         map.set('replaceIndex', replaceIndex);

--- a/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
+++ b/packages/netlify-cms-core/src/reducers/mediaLibrary.ts
@@ -49,7 +49,7 @@ const defaultState: {
   replaceIndex?: number;
 } = {
   isVisible: false,
-  showMediaButton: true,
+  showMediaButton: false,
   controlMedia: Map(),
   displayURLs: Map(),
   config: Map(),

--- a/packages/netlify-cms-core/src/reducers/medias.ts
+++ b/packages/netlify-cms-core/src/reducers/medias.ts
@@ -3,10 +3,14 @@ import { produce } from 'immer';
 import {
   ADD_ASSETS,
   ADD_ASSET,
+  REMOVE_ASSETS,
   REMOVE_ASSET,
   LOAD_ASSET_REQUEST,
   LOAD_ASSET_SUCCESS,
   LOAD_ASSET_FAILURE,
+  getEntryMediaFilePath,
+  getEntryMapMediaFilePath,
+  getMediaFilePath,
 } from '../actions/media';
 
 import type { MediasAction } from '../actions/media';
@@ -21,20 +25,29 @@ const defaultState: Medias = {};
 const medias = produce((state: Medias, action: MediasAction) => {
   switch (action.type) {
     case ADD_ASSETS: {
-      const assets = action.payload;
+      const { entry, assets } = action.payload;
       assets.forEach(asset => {
-        state[asset.path] = { asset, isLoading: false, error: null };
+        const resolvedPath = getEntryMediaFilePath(entry, asset.path);
+        state[resolvedPath] = { asset, isLoading: false, error: null };
       });
       break;
     }
     case ADD_ASSET: {
-      const asset = action.payload;
-      state[asset.path] = { asset, isLoading: false, error: null };
+      const { entry, asset } = action.payload;
+      const resolvedPath = getEntryMapMediaFilePath(entry, asset.path);
+      state[resolvedPath] = { asset, isLoading: false, error: null };
+      break;
+    }
+    case REMOVE_ASSETS: {
+      Object.keys(state).forEach(path => {
+        delete state[path];
+      });
       break;
     }
     case REMOVE_ASSET: {
-      const path = action.payload;
-      delete state[path];
+      const { entryPath, path } = action.payload;
+      const resolvedPath = getMediaFilePath(entryPath, path);
+      delete state[resolvedPath];
       break;
     }
     case LOAD_ASSET_REQUEST: {

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -1,9 +1,11 @@
 import type { Action } from 'redux';
+import type { Options as PrettierOptions } from 'prettier';
 import type { StaticallyTypedRecord } from './immutable';
 import type { Map, List, OrderedMap, Set } from 'immutable';
 import type { FILES, FOLDER } from '../constants/collectionTypes';
 import type { MediaFile as BackendMediaFile } from '../backend';
 import type { Auth } from '../reducers/auth';
+import type { MainStatus } from '../reducers/main';
 import type { Status } from '../reducers/status';
 import type { Medias } from '../reducers/medias';
 import type { Deploys } from '../reducers/deploys';
@@ -360,6 +362,7 @@ export interface CmsBackend {
   auth_scope?: CmsAuthScope;
   open_authoring?: boolean;
   repo?: string;
+  main?: string;
   branch?: string;
   api_root?: string;
   site_domain?: string;
@@ -369,6 +372,7 @@ export interface CmsBackend {
   squash_merges?: boolean;
   proxy_url?: string;
   commit_messages?: {
+    main?: string;
     create?: string;
     update?: string;
     delete?: string;
@@ -620,6 +624,8 @@ type i18n = StaticallyTypedRecord<{
 
 export type Format = keyof typeof formatExtensions;
 
+export type PrettierMapOptions = Map<keyof PrettierOptions, PrettierOptions[keyof PrettierOptions]>
+
 type CollectionObject = {
   name: string;
   folder?: string;
@@ -635,6 +641,7 @@ type CollectionObject = {
   type: 'file_based_collection' | 'folder_based_collection';
   extension?: string;
   format?: Format;
+  prettier?: PrettierMapOptions;
   frontmatter_delimiter?: List<string> | string | [string, string];
   create?: boolean;
   delete?: boolean;
@@ -718,6 +725,7 @@ export interface State {
   mediaLibrary: MediaLibrary;
   search: Search;
   notifs: { message: { key: string }; kind: string; id: number }[];
+  main: MainStatus;
   status: Status;
 }
 

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -128,6 +128,7 @@ export interface CmsFieldFileOrImage {
   default?: string;
 
   media_library?: CmsMediaLibrary;
+  media_validation?: CmsMediaValidation;
   allow_multiple?: boolean;
   choose_url?: boolean;
   config?: unknown;
@@ -400,6 +401,7 @@ export interface CmsConfig {
   public_folder?: string;
   media_folder_relative?: boolean;
   media_library?: CmsMediaLibrary;
+  media_validation?: CmsMediaValidation;
   publish_mode?: CmsPublishMode;
   load_config_file?: boolean;
   integrations?: {
@@ -425,6 +427,23 @@ export type CmsMediaLibraryOptions = unknown; // TODO: type properly
 export interface CmsMediaLibrary {
   name: string;
   config?: CmsMediaLibraryOptions;
+}
+
+export interface CmsMediaImageValidation {
+  aspect_ratio: string
+  keep_aspect_ratio: boolean;
+  max_width: number
+  max_height: number
+  min_width: number
+  min_height: number
+}
+
+export interface CmsMediaValidation {
+  file_extensions: Array<string>
+  keep_file_name: boolean
+  max_file_size: number
+  file_name_pattern: string
+  images?: CmsMediaImageValidation;
 }
 
 export type SlugConfig = StaticallyTypedRecord<{

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -554,7 +554,6 @@ export type EntryField = StaticallyTypedRecord<{
   widget: string;
   name: string;
   default: string | null | boolean | List<unknown>;
-  file_name?: string;
   media_folder?: string;
   public_folder?: string;
   comment?: string;

--- a/packages/netlify-cms-core/src/types/redux.ts
+++ b/packages/netlify-cms-core/src/types/redux.ts
@@ -554,6 +554,7 @@ export type EntryField = StaticallyTypedRecord<{
   widget: string;
   name: string;
   default: string | null | boolean | List<unknown>;
+  file_name?: string;
   media_folder?: string;
   public_folder?: string;
   comment?: string;

--- a/packages/netlify-cms-lib-util/src/APIUtils.ts
+++ b/packages/netlify-cms-lib-util/src/APIUtils.ts
@@ -4,8 +4,18 @@ export const MERGE_COMMIT_MESSAGE = 'Automatically generated. Merged on Netlify 
 
 const DEFAULT_NETLIFY_CMS_LABEL_PREFIX = 'netlify-cms/';
 
+export const REF_SUFFIX = (() => {
+  const { pathname } = window.location;
+  const cleanPathname = pathname.replace(/^\//, '');
+  return cleanPathname ? `(${cleanPathname})` : '';
+})();
+
 function getLabelPrefix(labelPrefix: string) {
   return labelPrefix || DEFAULT_NETLIFY_CMS_LABEL_PREFIX;
+}
+
+export function isCmsRefSuffix(ref: string) {
+  return ref.endsWith(REF_SUFFIX)
 }
 
 export function isCMSLabel(label: string, labelPrefix: string) {
@@ -21,12 +31,15 @@ export function statusToLabel(status: string, labelPrefix: string) {
 }
 
 export function generateContentKey(collectionName: string, slug: string) {
-  return `${collectionName}/${slug}`;
+  return `${collectionName}/${slug}${REF_SUFFIX}`;
 }
 
 export function parseContentKey(contentKey: string) {
   const index = contentKey.indexOf('/');
-  return { collection: contentKey.slice(0, index), slug: contentKey.slice(index + 1) };
+  return {
+    collection: contentKey.slice(0, index),
+    slug: contentKey.slice(index + 1).replace(REF_SUFFIX, ''),
+  };
 }
 
 export function contentKeyFromBranch(branch: string) {

--- a/packages/netlify-cms-lib-util/src/__tests__/backendUtil.spec.js
+++ b/packages/netlify-cms-lib-util/src/__tests__/backendUtil.spec.js
@@ -1,7 +1,13 @@
 import { oneLine } from 'common-tags';
 import nock from 'nock';
 
-import { parseLinkHeader, getAllResponses, getPathDepth, filterByExtension } from '../backendUtil';
+import {
+  parseLinkHeader,
+  getAllResponses,
+  getPathDepth,
+  filterByIndexFile,
+  filterByExtension,
+} from '../backendUtil';
 
 describe('parseLinkHeader', () => {
   it('should return the right rel urls', () => {
@@ -81,6 +87,20 @@ describe('getPathDepth', () => {
 
   it('should return 2 for path of one nested folder', () => {
     expect(getPathDepth('{{year}}/{{slug}}')).toBe(2);
+  });
+});
+
+describe('filterByIndexFile', () => {
+  it('should return true when filename matches index_file', () => {
+    expect(filterByIndexFile({ path: 'foo/index.md' }, 'index')).toBe(true);
+  });
+
+  it('should return true when index_file is not defined', () => {
+    expect(filterByIndexFile({ path: 'foo/index.md' })).toBe(true);
+  });
+
+  it("should return false when filename doesn't match index_file", () => {
+    expect(filterByIndexFile({ path: 'foo/var.md' }, 'index')).toBe(false);
   });
 });
 

--- a/packages/netlify-cms-lib-util/src/backendUtil.ts
+++ b/packages/netlify-cms-lib-util/src/backendUtil.ts
@@ -7,6 +7,14 @@ import APIError from './APIError';
 
 type Formatter = (res: Response) => Promise<string | Blob | unknown>;
 
+export function filterByIndexFile(file: { path: string }, indexFile: string) {
+  if (!indexFile) return true;
+  const path = file?.path || '';
+  const splittedPath = path.split('/');
+  const fileName = splittedPath[splittedPath.length - 1].split('.')[0];
+  return fileName === indexFile;
+}
+
 export function filterByExtension(file: { path: string }, extension: string) {
   const path = file?.path || '';
   return path.endsWith(extension.startsWith('.') ? extension : `.${extension}`);

--- a/packages/netlify-cms-lib-util/src/implementation.ts
+++ b/packages/netlify-cms-lib-util/src/implementation.ts
@@ -100,6 +100,7 @@ export type Config = {
     repo?: string | null;
     open_authoring?: boolean;
     always_fork?: boolean;
+    main?: string;
     branch?: string;
     api_root?: string;
     squash_merges?: boolean;
@@ -172,6 +173,7 @@ export interface Implementation {
     slug: string,
     newStatus: string,
   ) => Promise<void>;
+  publishUnpublishedEntryMain: (collection: string, slug: string, options: { mainCommitMessage: string, publishMain?: boolean }) => Promise<void>;
   publishUnpublishedEntry: (collection: string, slug: string) => Promise<void>;
   deleteUnpublishedEntry: (collection: string, slug: string) => Promise<void>;
   getDeployPreview: (
@@ -195,6 +197,14 @@ export interface Implementation {
     auth: { status: boolean };
     api: { status: boolean; statusPage: string };
   }>;
+  mainStatus: () => Promise<{
+    status?: string;
+    updatedAt?: string;
+  } | undefined>;
+  updateMainStatus: (newStatus: string) => Promise<void>;
+  publishMain: () => Promise<void>;
+  closeMain: () => Promise<void>;
+  createMainPR: (title?: string) => Promise<void>;
 }
 
 const MAX_CONCURRENT_DOWNLOADS = 10;

--- a/packages/netlify-cms-lib-util/src/index.ts
+++ b/packages/netlify-cms-lib-util/src/index.ts
@@ -7,6 +7,7 @@ import { isAbsolutePath, basename, fileExtensionWithSeparator, fileExtension } f
 import { onlySuccessfulPromises, flowAsync, then } from './promise';
 import unsentRequest from './unsentRequest';
 import {
+  filterByIndexFile,
   filterByExtension,
   getAllResponses,
   parseLinkHeader,
@@ -67,6 +68,7 @@ import type {
   ImplementationFile as IF,
   DisplayURLObject as DUO,
   DisplayURL as DU,
+  GoogleCredentials as GoogleCred,
   Credentials as Cred,
   User as U,
   Entry as E,
@@ -87,6 +89,7 @@ export type ImplementationMediaFile = IMF;
 export type ImplementationFile = IF;
 export type DisplayURL = DU;
 export type DisplayURLObject = DUO;
+export type GoogleCredentials = GoogleCred;
 export type Credentials = Cred;
 export type User = U;
 export type Entry = E;
@@ -113,6 +116,7 @@ export const NetlifyCmsLibUtil = {
   flowAsync,
   then,
   unsentRequest,
+  filterByIndexFile,
   filterByExtension,
   parseLinkHeader,
   parseResponse,
@@ -166,6 +170,7 @@ export {
   flowAsync,
   then,
   unsentRequest,
+  filterByIndexFile,
   filterByExtension,
   parseLinkHeader,
   getAllResponses,

--- a/packages/netlify-cms-lib-util/src/index.ts
+++ b/packages/netlify-cms-lib-util/src/index.ts
@@ -40,6 +40,7 @@ import {
 import {
   CMS_BRANCH_PREFIX,
   generateContentKey,
+  isCmsRefSuffix,
   isCMSLabel,
   labelToStatus,
   statusToLabel,
@@ -133,6 +134,7 @@ export const NetlifyCmsLibUtil = {
   readFileMetadata,
   CMS_BRANCH_PREFIX,
   generateContentKey,
+  isCmsRefSuffix,
   isCMSLabel,
   labelToStatus,
   statusToLabel,
@@ -190,6 +192,7 @@ export {
   readFileMetadata,
   CMS_BRANCH_PREFIX,
   generateContentKey,
+  isCmsRefSuffix,
   isCMSLabel,
   labelToStatus,
   statusToLabel,

--- a/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
@@ -247,7 +247,7 @@ export function addFileTemplateFields(entryPath: string, fields: Map<string, str
     map.set('dirname', dirnameExcludingFolder);
     map.set('filename', filename);
     map.set('extension', extension === '' ? extension : extension.slice(1));
-    map.set('route', route);
+    map.set('route', route === '.' ? '' : route);
     map.set('lang', lang);
   });
 

--- a/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
+++ b/packages/netlify-cms-lib-widgets/src/stringTemplate.ts
@@ -238,10 +238,17 @@ export function addFileTemplateFields(entryPath: string, fields: Map<string, str
   const extension = extname(entryPath);
   const filename = basename(entryPath, extension);
   const dirnameExcludingFolder = dirname(entryPath).replace(new RegExp(`^(/?)${folder}/?`), '$1');
+
+  const dirnameExcludingFolderParent = dirnameExcludingFolder.replace(new RegExp(`^[^/]*/`), '');
+  const route = dirname(dirnameExcludingFolderParent).replace(new RegExp(`^(/?)__root/?`), '$1');
+  const lang = basename(dirnameExcludingFolderParent);
+
   fields = fields.withMutations(map => {
     map.set('dirname', dirnameExcludingFolder);
     map.set('filename', filename);
     map.set('extension', extension === '' ? extension : extension.slice(1));
+    map.set('route', route);
+    map.set('lang', lang);
   });
 
   return fields;

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -224,6 +224,8 @@ const en = {
     mediaLibrary: {
       onDelete: 'Are you sure you want to delete selected media?',
       fileTooLarge: 'File too large.\nConfigured to not allow files greater than %{size} kB.',
+      fileNamePatternError: 'The name of the file must be with this pattern:\n\n%{pattern}\n\nPlease rename the file with a correct file name in order to continue.',
+      fileNameCheckReplacement: 'The name of the file must be %{fileName}.\n\nDo you want to make the name replacement?',
     },
     mediaLibraryModal: {
       loading: 'Loading...',

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -225,7 +225,6 @@ const en = {
       onDelete: 'Are you sure you want to delete selected media?',
       fileTooLarge: 'File too large.\nConfigured to not allow files greater than %{size} kB.',
       fileNamePatternError: 'The name of the file must be with this pattern:\n\n%{pattern}\n\nPlease rename the file with a correct file name in order to continue.',
-      fileNameCheckReplacement: 'The name of the file must be %{fileName}.\n\nDo you want to make the name replacement?',
     },
     mediaLibraryModal: {
       loading: 'Loading...',

--- a/packages/netlify-cms-locales/src/en/index.js
+++ b/packages/netlify-cms-locales/src/en/index.js
@@ -110,9 +110,11 @@ const en = {
       onDeleteUnpublishedChangesWithUnsavedChanges:
         'This will delete all unpublished changes to this entry, as well as your unsaved changes from the current session. Do you still want to delete?',
       onDeleteUnpublishedChanges:
-        'All unpublished changes to this entry will be deleted. Do you still want to delete?',
+        'All changes to this entry will be deleted.\n\n Do you still want to delete?',
       loadingEntry: 'Loading entry...',
       confirmLoadBackup: 'A local backup was recovered for this entry, would you like to use it?',
+      onMainPublishing: 'Are you sure you want to publish all changes?',
+      onMainClosing: 'Are you sure you want to discard all changes?',
     },
     editorInterface: {
       toggleI18n: 'Toggle i18n',
@@ -125,9 +127,10 @@ const en = {
       published: 'Published',
       unpublish: 'Unpublish',
       duplicate: 'Duplicate',
-      unpublishing: 'Unpublishing...',
+      unpublishing: 'Loading...',
       publishAndCreateNew: 'Publish and create new',
       publishAndDuplicate: 'Publish and duplicate',
+      discardChanges: 'Discard changes',
       deleteUnpublishedChanges: 'Delete unpublished changes',
       deleteUnpublishedEntry: 'Delete unpublished entry',
       deletePublishedEntry: 'Delete published entry',
@@ -138,6 +141,7 @@ const en = {
         'Entry status is set to draft. To finalize and submit it for review, set the status to ‘In review’',
       statusInfoTooltipInReview:
         'Entry is being reviewed, no further actions are required. However, you can still make additional changes while it is being reviewed.',
+      discarding: 'Discarding...',
       deleting: 'Deleting...',
       updating: 'Updating...',
       status: 'Status: %{status}',
@@ -148,6 +152,7 @@ const en = {
       inReview: 'In review',
       ready: 'Ready',
       publishNow: 'Publish now',
+      stackChange: 'Stack change',
       deployPreviewPendingButtonLabel: 'Check for Preview',
       deployPreviewButtonLabel: 'View Preview',
       deployButtonLabel: 'View Live',
@@ -281,6 +286,9 @@ const en = {
       onLoggedOut: 'You have been logged out, please back up any data and login again',
       onBackendDown:
         'The backend service is experiencing an outage. See %{details} for more information',
+      mainUpdated: 'Status updated',
+      mainPublished: 'Changes published',
+      mainClosed: 'Changes discarded',
     },
   },
   workflow: {

--- a/packages/netlify-cms-proxy-server/src/middlewares/localFs/index.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/localFs/index.ts
@@ -41,12 +41,13 @@ export function localFsMiddleware({ repoPath, logger }: FsOptions) {
         }
         case 'entriesByFolder': {
           const payload = body.params as EntriesByFolderParams;
-          const { folder, extension, depth } = payload;
-          const entries = await listRepoFiles(repoPath, folder, extension, depth).then(files =>
-            entriesFromFiles(
-              repoPath,
-              files.map(file => ({ path: file })),
-            ),
+          const { folder, extension, depth, indexFile } = payload;
+          const entries = await listRepoFiles(repoPath, folder, extension, depth, indexFile).then(
+            files =>
+              entriesFromFiles(
+                repoPath,
+                files.map(file => ({ path: file })),
+              ),
           );
           res.json(entries);
           break;
@@ -91,7 +92,7 @@ export function localFsMiddleware({ repoPath, logger }: FsOptions) {
         }
         case 'getMedia': {
           const { mediaFolder } = body.params as GetMediaParams;
-          const files = await listRepoFiles(repoPath, mediaFolder, '', 1);
+          const files = await listRepoFiles(repoPath, mediaFolder, '', 1, '');
           const mediaFiles = await Promise.all(files.map(file => readMediaFile(repoPath, file)));
           res.json(mediaFiles);
           break;

--- a/packages/netlify-cms-proxy-server/src/middlewares/localGit/index.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/localGit/index.ts
@@ -200,9 +200,9 @@ export function localGitMiddleware({ repoPath, logger }: GitOptions) {
       switch (body.action) {
         case 'entriesByFolder': {
           const payload = body.params as EntriesByFolderParams;
-          const { folder, extension, depth } = payload;
+          const { folder, extension, depth, indexFile } = payload;
           const entries = await runOnBranch(git, branch, () =>
-            listRepoFiles(repoPath, folder, extension, depth).then(files =>
+            listRepoFiles(repoPath, folder, extension, depth, indexFile).then(files =>
               entriesFromFiles(
                 repoPath,
                 files.map(file => ({ path: file })),
@@ -367,7 +367,7 @@ export function localGitMiddleware({ repoPath, logger }: GitOptions) {
         case 'getMedia': {
           const { mediaFolder } = body.params as GetMediaParams;
           const mediaFiles = await runOnBranch(git, branch, async () => {
-            const files = await listRepoFiles(repoPath, mediaFolder, '', 1);
+            const files = await listRepoFiles(repoPath, mediaFolder, '', 1, '');
             const serializedFiles = await Promise.all(
               files.map(file => readMediaFile(repoPath, file)),
             );

--- a/packages/netlify-cms-proxy-server/src/middlewares/types.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/types.ts
@@ -6,6 +6,7 @@ export type EntriesByFolderParams = {
   folder: string;
   extension: string;
   depth: 1;
+  indexFile: string;
 };
 
 export type EntriesByFilesParams = {

--- a/packages/netlify-cms-proxy-server/src/middlewares/utils/fs.ts
+++ b/packages/netlify-cms-proxy-server/src/middlewares/utils/fs.ts
@@ -1,7 +1,12 @@
 import path from 'path';
 import { promises as fs } from 'fs';
 
-async function listFiles(dir: string, extension: string, depth: number): Promise<string[]> {
+async function listFiles(
+  dir: string,
+  extension: string,
+  depth: number,
+  indexFile: string,
+): Promise<string[]> {
   if (depth <= 0) {
     return [];
   }
@@ -12,7 +17,7 @@ async function listFiles(dir: string, extension: string, depth: number): Promise
       dirents.map(dirent => {
         const res = path.join(dir, dirent.name);
         return dirent.isDirectory()
-          ? listFiles(res, extension, depth - 1)
+          ? listFiles(res, extension, depth - 1, indexFile)
           : [res].filter(f => f.endsWith(extension));
       }),
     );
@@ -27,8 +32,9 @@ export async function listRepoFiles(
   folder: string,
   extension: string,
   depth: number,
+  indexFile: string,
 ) {
-  const files = await listFiles(path.join(repoPath, folder), extension, depth);
+  const files = await listFiles(path.join(repoPath, folder), extension, depth, indexFile);
   return files.map(f => f.slice(repoPath.length + 1));
 }
 
@@ -53,7 +59,7 @@ export async function move(from: string, to: string) {
   // move children
   const sourceDir = path.dirname(from);
   const destDir = path.dirname(to);
-  const allFiles = await listFiles(sourceDir, '', 100);
+  const allFiles = await listFiles(sourceDir, '', 100, '');
   await Promise.all(allFiles.map(file => moveFile(file, file.replace(sourceDir, destDir))));
 }
 

--- a/packages/netlify-cms-widget-file/src/withFileControl.js
+++ b/packages/netlify-cms-widget-file/src/withFileControl.js
@@ -130,10 +130,10 @@ const FileWidgetButton = styled.button`
   margin-bottom: 12px;
 `;
 
-const FileWidgetButtonRemove = styled.button`
-  ${buttons.button};
-  ${components.badgeDanger};
-`;
+// const FileWidgetButtonRemove = styled.button`
+//   ${buttons.button};
+//   ${components.badgeDanger};
+// `;
 
 function isMultiple(value) {
   return Array.isArray(value) || List.isList(value);
@@ -232,6 +232,7 @@ export default function withFileControl({ forImage } = {}) {
       const { field, onOpenMediaLibrary, value } = this.props;
       e.preventDefault();
       const mediaLibraryFieldOptions = this.getMediaLibraryFieldOptions();
+      const validation = this.getMediaLibraryValidationOptions();
 
       return onOpenMediaLibrary({
         controlID: this.controlID,
@@ -240,6 +241,7 @@ export default function withFileControl({ forImage } = {}) {
         value: valueListToArray(value),
         allowMultiple: !!mediaLibraryFieldOptions.get('allow_multiple', true),
         config: mediaLibraryFieldOptions.get('config'),
+        validation,
         field,
       });
     };
@@ -270,6 +272,7 @@ export default function withFileControl({ forImage } = {}) {
 
       return onOpenMediaLibrary({
         controlID: this.controlID,
+        fileExtensions: field.get('file_extensions'),
         forImage,
         privateUpload: field.get('private'),
         value: valueListToArray(value),
@@ -278,6 +281,12 @@ export default function withFileControl({ forImage } = {}) {
         config: mediaLibraryFieldOptions.get('config'),
         field,
       });
+    };
+
+    getMediaLibraryValidationOptions = () => {
+      const { field } = this.props;
+
+      return field.get('media_validation', Map());
     };
 
     getMediaLibraryFieldOptions = () => {
@@ -373,7 +382,7 @@ export default function withFileControl({ forImage } = {}) {
 
     renderSelection = subject => {
       const { t, field } = this.props;
-      const allowsMultiple = this.allowsMultiple();
+      // const allowsMultiple = this.allowsMultiple();
       return (
         <div>
           {forImage ? this.renderImages() : null}
@@ -391,9 +400,9 @@ export default function withFileControl({ forImage } = {}) {
                 {t(`editor.editorWidgets.${subject}.replaceUrl`)}
               </FileWidgetButton>
             ) : null}
-            <FileWidgetButtonRemove onClick={this.handleRemove}>
+            {/* <FileWidgetButtonRemove onClick={this.handleRemove}>
               {t(`editor.editorWidgets.${subject}.remove${allowsMultiple ? 'All' : ''}`)}
-            </FileWidgetButtonRemove>
+            </FileWidgetButtonRemove> */}
           </div>
         </div>
       );

--- a/yarn.lock
+++ b/yarn.lock
@@ -14475,10 +14475,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.3.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
-  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
+prettier@^2.8.8:
+  version "2.8.8"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
+  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
 
 pretty-bytes@^5.6.0:
   version "5.6.0"


### PR DESCRIPTION
## 📱 Which kind of feature is this PR?

This PR includes all the work done through out the last year made on my personal fork of `netlify-cms`.

## ℹ️ What's this PR do?

You can see on the commits history everything that has been done but the main functionalities added are:
- Added `google auth` compatibility (This was necessary when we had multiple repositories)
- Added `media_library` validations like size check, name check, aspect-ratio check...
- Removed `backup` functionality to avoid issues with changes (Wasn't working well...)
- Added new `stack` changes workflow
- Added `prettier` linter

## 📱 How should this be tested?

> In order to test this make sure you are using `node v16`  

1. Checkout `feature/PNW-1326_cms-fork-migration`
2. Run `yarn install`

- [x] Test that `yarn build` works correctly
- [x] Test that the output generated on `netlify-cms/dist` works as the current one we have on `landings-cms`
- [ ] Test that the new workflow still works as expected checkout this [PR](https://github.com/Feverup/landings-cms/pull/357) to see the config necessary