### PR TITLE
PNW-1531 - complex data structure flat and wrap functionality

### DIFF
--- a/packages/netlify-cms-core/src/components/Collection/NestedCollection.js
+++ b/packages/netlify-cms-core/src/components/Collection/NestedCollection.js
@@ -84,13 +84,14 @@ function TreeNode(props) {
     if (leaf) {
       return null;
     }
+
     let to = `/collections/${collectionName}`;
     if (depth > 0) {
       to = `${to}/filter${node.path}`;
     }
     const title = getNodeTitle(node);
 
-    const hasChildren = depth === 0 || node.children.some(c => c.children.some(c => c.isDir));
+    const hasChildren = node.children.some(c => c.children.some(c => c.isDir));
 
     return (
       <React.Fragment key={node.path}>

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -211,6 +211,8 @@ class EditorControl extends React.Component {
       locale,
     } = this.props;
 
+    const widgetTitle = field.get('title');
+    const widgetSubtitle = field.get('subtitle');
     const widgetName = field.get('widget');
     const widget = resolveWidget(widgetName);
     const fieldName = field.get('name');
@@ -221,6 +223,7 @@ class EditorControl extends React.Component {
     const errors = fieldsErrors && fieldsErrors.get(this.uniqueFieldId);
     const childErrors = this.isAncestorOfFieldError();
     const hasErrors = !!errors || childErrors;
+    const isFlat = widgetName === 'object' && field.has('flat');
 
     return (
       <ClassNames>
@@ -231,6 +234,8 @@ class EditorControl extends React.Component {
               ${isHidden && styleStrings.hidden};
             `}
           >
+            {widgetTitle && <h1>{widgetTitle}</h1>}
+            {widgetSubtitle && <h2>{widgetSubtitle}</h2>}
             {widget.globalStyles && <Global styles={coreCss`${widget.globalStyles}`} />}
             {errors && (
               <ControlErrorsList>
@@ -245,14 +250,14 @@ class EditorControl extends React.Component {
                 )}
               </ControlErrorsList>
             )}
-            <LabelComponent
+            {!isFlat && <LabelComponent
               field={field}
               isActive={isSelected || this.state.styleActive}
               hasErrors={hasErrors}
               uniqueFieldId={this.uniqueFieldId}
               isFieldOptional={isFieldOptional}
               t={t}
-            />
+            />}
             <Widget
               classNameWrapper={cx(
                 css`
@@ -296,6 +301,7 @@ class EditorControl extends React.Component {
               mediaPaths={mediaPaths}
               metadata={metadata}
               onChange={(newValue, newMetadata) => onChange(field, newValue, newMetadata)}
+              onChangeObject={onChange}
               onValidate={onValidate && partial(onValidate, this.uniqueFieldId)}
               onOpenMediaLibrary={openMediaLibrary}
               onClearMediaControl={clearMediaControl}

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -212,7 +212,6 @@ class EditorControl extends React.Component {
     } = this.props;
 
     const widgetTitle = field.get('title');
-    const widgetSubtitle = field.get('subtitle');
     const widgetName = field.get('widget');
     const widget = resolveWidget(widgetName);
     const fieldName = field.get('name');
@@ -235,7 +234,6 @@ class EditorControl extends React.Component {
             `}
           >
             {widgetTitle && <h1>{widgetTitle}</h1>}
-            {widgetSubtitle && <h2>{widgetSubtitle}</h2>}
             {widget.globalStyles && <Global styles={coreCss`${widget.globalStyles}`} />}
             {errors && (
               <ControlErrorsList>

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js
@@ -91,6 +91,13 @@ function getFieldValue({ field, entry, isTranslatable, locale }) {
     return entry.getIn([...dataPath, field.get('name')]);
   }
 
+  const wrapper = field.has('wrapper');
+  if (wrapper) {
+    const wrapper = field.get('wrapper');
+    const isRootWrapper = wrapper === '';
+    return isRootWrapper ? entry.get('data') : entry.getIn(['data', ...wrapper.split('.')]);
+  }
+
   return entry.getIn(['data', field.get('name')]);
 }
 
@@ -103,9 +110,12 @@ export default class ControlPane extends React.Component {
 
   controlRef(field, wrappedControl) {
     if (!wrappedControl) return;
+    const parentName = field.get('parentName');
     const name = field.get('name');
 
-    this.componentValidate[name] =
+    const validateName = parentName ? `${parentName}.${name}` : name;
+
+    this.componentValidate[validateName] =
       wrappedControl.innerWrappedControl?.validate || wrappedControl.validate;
   }
 
@@ -116,43 +126,49 @@ export default class ControlPane extends React.Component {
 
   copyFromOtherLocale =
     ({ targetLocale, t }) =>
-    sourceLocale => {
-      if (
-        !window.confirm(
-          t('editor.editorControlPane.i18n.copyFromLocaleConfirm', {
-            locale: sourceLocale.toUpperCase(),
-          }),
-        )
-      ) {
-        return;
-      }
-      const { entry, collection } = this.props;
-      const { locales, defaultLocale } = getI18nInfo(collection);
-
-      const locale = this.state.selectedLocale;
-      const i18n = locales && {
-        currentLocale: locale,
-        locales,
-        defaultLocale,
-      };
-
-      this.props.fields.forEach(field => {
-        if (isFieldTranslatable(field, targetLocale, sourceLocale)) {
-          const copyValue = getFieldValue({
-            field,
-            entry,
-            locale: sourceLocale,
-            isTranslatable: sourceLocale !== defaultLocale,
-          });
-          this.props.onChange(field, copyValue, undefined, i18n);
+      sourceLocale => {
+        if (
+          !window.confirm(
+            t('editor.editorControlPane.i18n.copyFromLocaleConfirm', {
+              locale: sourceLocale.toUpperCase(),
+            }),
+          )
+        ) {
+          return;
         }
-      });
-    };
+        const { entry, collection } = this.props;
+        const { locales, defaultLocale } = getI18nInfo(collection);
+
+        const locale = this.state.selectedLocale;
+        const i18n = locales && {
+          currentLocale: locale,
+          locales,
+          defaultLocale,
+        };
+
+        this.props.fields.forEach(field => {
+          if (isFieldTranslatable(field, targetLocale, sourceLocale)) {
+            const copyValue = getFieldValue({
+              field,
+              entry,
+              locale: sourceLocale,
+              isTranslatable: sourceLocale !== defaultLocale,
+            });
+            this.props.onChange(field, copyValue, undefined, i18n);
+          }
+        });
+      };
 
   validate = async () => {
     this.props.fields.forEach(field => {
-      if (field.get('widget') === 'hidden') return;
-      this.componentValidate[field.get('name')]();
+      const widget = field.get('widget');
+      if (widget === 'hidden' || widget === 'object' && field.has('flat')) return;
+
+      const parentName = field.get('parentName');
+      const name = field.get('name');
+
+      const validateName = parentName ? `${parentName}.${name}` : name;
+      this.componentValidate[validateName]();
     });
   };
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -233,9 +233,15 @@ export default class Widget extends Component {
    * Change handler for fields that are nested within another field.
    */
   onChangeObject = (field, newValue, newMetadata) => {
-    const newObjectValue = this.getObjectValue().set(field.get('name'), newValue);
-    return this.props.onChange(
-      newObjectValue,
+    const isWrapper = this.props.field.has('wrapper');
+    const parentName = field.get('parentName');
+    const newObjectValue = parentName ?
+      this.getObjectValue().setIn([...parentName.split('.'), field.get('name')], newValue) :
+      this.getObjectValue().set(field.get('name'), newValue);
+
+    return this.props.onChangeObject(
+      isWrapper ? field : this.props.field,
+      isWrapper ? newValue : newObjectValue,
       newMetadata && { [this.props.field.get('name')]: newMetadata },
     );
   };

--- a/packages/netlify-cms-core/src/reducers/entryDraft.js
+++ b/packages/netlify-cms-core/src/reducers/entryDraft.js
@@ -104,6 +104,10 @@ function entryDraftReducer(state = Map(), action) {
         const meta = field.get('meta');
 
         const dataPath = (i18n && getDataPath(i18n.currentLocale, i18n.defaultLocale)) || ['data'];
+
+        const parentName = field.get('parentName');
+        if (parentName) dataPath.push(...parentName.split('.'));
+
         if (meta) {
           state.setIn(['entry', 'meta', name], value);
         } else {

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -78,9 +78,26 @@ export default class ObjectControl extends React.Component {
     });
   };
 
+  getFieldValue(field) {
+    const { value } = this.props;
+
+    const isWrapper = field.has('wrapper');
+    if (isWrapper) {
+      const wrapper = field.get('wrapper');
+      const isRootWrapper = wrapper === '';
+
+      return isRootWrapper ? value : value.getIn([...wrapper.split('.')]);
+    }
+
+    const fieldName = field.get('name');
+    const parentName = field.get('parentName');
+    if (parentName) return value.getIn([...(parentName.split('.')), fieldName]);
+
+    return value.get(fieldName);
+  }
+
   controlFor(field, key) {
     const {
-      value,
       onChangeObject,
       onValidateObject,
       clearFieldErrors,
@@ -97,13 +114,8 @@ export default class ObjectControl extends React.Component {
     if (field.get('widget') === 'hidden') {
       return null;
     }
-    const fieldName = field.get('name');
-    const parentName = field.get('parentName');
-    const fieldValue = value && Map.isMap(value) ?
-      (parentName ?
-        value.getIn([...(parentName.split('.')), fieldName]) :
-        value.get(fieldName)
-      ) : value;
+
+    const fieldValue = this.getFieldValue(field)
 
     const isDuplicate = isFieldDuplicate && isFieldDuplicate(field);
     const isHidden = isFieldHidden && isFieldHidden(field);

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -158,8 +158,8 @@ export default class ObjectControl extends React.Component {
     const notordered = [];
     renderedFields.forEach(render => {
       const { field } = render.props;
-      const parentName = field.get('parentName');
       const name = field.get('name');
+      const parentName = field.get('parentName');
       const orderKey = parentName ? `${parentName}.${name}` : name;
       if (orderMap[orderKey]) {
         return orderMap[orderKey].push(render);
@@ -178,9 +178,11 @@ export default class ObjectControl extends React.Component {
         if (isFlat) {
           const name = f.get('name');
           const parentName = f.get('parentName');
+
           const fieldParentName = parentName ? `${parentName}.${name}` : name;
           const multiFields = f.get('fields')?.map(field => field.set('parentName', fieldParentName));
           const singleField = f.get('field')?.set('parentName', fieldParentName);
+
           return mappedMultiFields.push(...this.renderFields(multiFields, singleField, f));
         }
         return mappedMultiFields.push(this.controlFor(f, idx));


### PR DESCRIPTION
## ℹ️ What's this PR do?

This PR adds new functionality to improve the forms from complex data structures.

- **Flat Functionality for Objects**: Added the ability to use the `flat` functionality with objects. This feature allows for the removal of unnecessary collapsed `div` elements, improving the user interface.

- **Wrap Functionality for Objects**: Introduced the `wrap` functionality for objects. This feature enables users to specify a different `key` for loading and editing data, even at the root level using `wrap: ""`. It facilitates the grouping of fields visually based on the data structure.

- **Title Display**: Implemented the `title` functionality. These enhancements provide a more visual way to locate and organize fields, especially useful when dealing with a large number of fields.

With these enhancements, users can now:

- Simplify the UI by removing unnecessary `div` elements using `flat`.
- Organize and group fields visually based on the data structure using `wrap`.
- Improve field visualization, especially when working with a large number of fields, by using `title`.

## 👀 Where should the reviewer start?

- `packages/netlify-cms-widget-object/src/ObjectControl.js`
- `packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js`
- `packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControlPane.js`
- `packages/netlify-cms-core/src/reducers/entryDraft.js`
- `packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js`
- `packages/netlify-cms-core/src/components/Collection/NestedCollection.js`

## 📱 How should this be tested?

To ensure the functionality works as expected, follow these steps:

1. Run `yarn build` to generate a new `netlify-cms.js`.

2. In the [PR](https://github.com/Feverup/landings-cms/pull/498/files) for `landings-cms`, replace the current files with the newly generated `netlify-cms.js`.

- [x] Test `flat` functionality by updating `src/config/collections/shared/config/config.json`. Remove all instances of `flat: true`, and verify that all fields load correctly.
- [x] Test `flat` functionality again by restoring `flat: true` in `src/config/collections/shared/config/config.json`. Ensure that fields load correctly while ignoring unnecessary object structures.
- [x] Test the `wrap` functionality by removing the `wrap: ""` on file `functions/lib/config/lib/fields.js` line 77. Confirm that data loads correctly and saving retains the correct data structure.
- [x] Test the `wrap` functionality again by restoring the `wrap: ""` on file `functions/lib/config/lib/fields.js` line 77. Verify that data loads correctly, and any changes are correctly applied to the data structure.
- [x] Confirm that the `title` displays as `<h1>` for improved visualization.


## 🤔  Any background context you want to provide?

Currently, a significant challenge arises from the complete dependency of the form structure on the underlying data structure. This becomes particularly problematic when dealing with complex data structures containing deep objects or a mixture of information. Displaying such data effectively within the form is challenging.

The introduction of these two functionalities addresses this issue by allowing users to group and configure the form's structure to align seamlessly with the actual data structure.

With this 2 functionalities now you can group and create a form structure rewarding of the actual data structure.

### Flat

The flat functionality allows you to eliminate unnecessary collapsed `div` elements from your user interface.

#### Without `flat`:

![image](https://github.com/Feverup/decap-cms/assets/59401547/05da2bf2-1d85-4ee6-8546-f853f5f4c4e9)

#### With `flat`:

![image](https://github.com/Feverup/decap-cms/assets/59401547/35a0801e-d422-441d-b9d9-5047a423438a)

### Wrap

The `wrap` feature provides flexibility in loading and editing data. Instead of relying on the default name key used by the CMS, you can specify a different key. This includes the ability to work with the root data using `wrap: ""`.

This functionality allows you to group various fields into a single visual unit, aligning with the existing data structure.

#### Without `wrap`:

![image](https://github.com/Feverup/decap-cms/assets/59401547/196aaa6b-49a6-4382-a124-02d159581658)

#### With `wrap` + `flat`:

![image](https://github.com/Feverup/decap-cms/assets/59401547/c1f26dce-beff-4333-9589-a00dffff6c94)

As demonstrated, the combination of wrap and flat significantly enhances the user interface by grouping fields effectively and removing unnecessary `div` elements.

### Title

The `title` feature allows you to include an `<h1>` element at the top of a field, providing a more visually distinctive way to locate and identify the field. This becomes especially valuable when dealing with a large number of fields.

## 📸 Screenshots (if appropriate)

#### TItle + Wrap + Flat

![image](https://github.com/Feverup/decap-cms/assets/59401547/47b8ee57-12ba-43ce-8562-37d0931c8aa3)
