### PR TITLE
PNW-1557 - Fix stack changes merge conflicts

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -830,8 +830,7 @@ export default class API {
     }
 
     console.log(
-      `Done migrating Pull Request '${
-        number === newNumber ? newNumber : `${number} => ${newNumber}`
+      `Done migrating Pull Request '${number === newNumber ? newNumber : `${number} => ${newNumber}`
       }'`,
     );
   }
@@ -986,8 +985,7 @@ export default class API {
     const unpublished = options.unpublished || false;
     if (this.useMain) await this.createBranchToMain();
     if (!unpublished) {
-      const branchData = (await this.getMainBranch()) || (await this.getDefaultBranch());
-      // const branchData = await this.getDefaultBranch();
+      const branchData = options.publishMain ? (await this.getMainBranch() || await this.getDefaultBranch()) : (await this.getDefaultBranch());
       const changeTree = await this.updateTree(branchData.commit.sha, files);
       const commitResponse = await this.commit(options.commitMessage, changeTree);
 

--- a/packages/netlify-cms-core/src/actions/entries.ts
+++ b/packages/netlify-cms-core/src/actions/entries.ts
@@ -884,7 +884,7 @@ export function getSerializedEntry(collection: Collection, entry: Entry) {
   return serializedEntry;
 }
 
-export function persistEntry(collection: Collection) {
+export function persistEntry(collection: Collection, publishMain?: boolean) {
   return async (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
     const state = getState();
     const entryDraft = state.entryDraft;
@@ -928,6 +928,7 @@ export function persistEntry(collection: Collection) {
         entryDraft: serializedEntryDraft,
         assetProxies,
         usedSlugs,
+        publishMain,
       })
       .then(async (newSlug: string) => {
         dispatch(

--- a/packages/netlify-cms-core/src/backend.ts
+++ b/packages/netlify-cms-core/src/backend.ts
@@ -273,6 +273,7 @@ interface PersistArgs {
   entryDraft: EntryDraft;
   assetProxies: AssetProxy[];
   usedSlugs: List<string>;
+  publishMain?: boolean;
   unpublished?: boolean;
   status?: string;
 }
@@ -1058,6 +1059,7 @@ export class Backend {
     entryDraft: draft,
     assetProxies,
     usedSlugs,
+    publishMain = false,
     unpublished = false,
     status,
   }: PersistArgs) {
@@ -1139,6 +1141,7 @@ export class Backend {
       commitMessage,
       collectionName,
       useWorkflow,
+      publishMain,
       ...updatedOptions,
     };
 

--- a/packages/netlify-cms-core/src/components/Editor/Editor.js
+++ b/packages/netlify-cms-core/src/components/Editor/Editor.js
@@ -224,7 +224,7 @@ export class Editor extends React.Component {
   // }
 
   handlePersistEntry = async (opts = {}) => {
-    const { createNew = false, duplicate = false } = opts;
+    const { createNew = false, duplicate = false, publishMain = false } = opts;
     const {
       persistEntry,
       collection,
@@ -236,7 +236,7 @@ export class Editor extends React.Component {
       entryDraft,
     } = this.props;
 
-    await persistEntry(collection);
+    await persistEntry(collection, publishMain);
 
     // this.deleteBackup();
 

--- a/packages/netlify-cms-lib-util/src/implementation.ts
+++ b/packages/netlify-cms-lib-util/src/implementation.ts
@@ -78,6 +78,7 @@ export type PersistOptions = {
   commitMessage: string;
   collectionName?: string;
   useWorkflow?: boolean;
+  publishMain?: boolean;
   unpublished?: boolean;
   status?: string;
 };


### PR DESCRIPTION
## ℹ️ What's this PR do?

- Resolve the existing problems related to branch creation when utilizing stack changes.

## 👀 Where should the reviewer start?

- `packages/netlify-cms-backend-github/src/API.ts`

## 📱 How should this be tested?

- [x]  Test that when making changes to a stack in the `Draft` state, the new changes are forked from the `stack` branch and not the `main` branch.

## 🤔  Any background context you want to provide?

The problem we want to address here is the issue we encountered when creating new changes while having stack changes. The problem was that the branch created for these new changes was always forked from `main`. This becomes problematic when `main` has changes, as any changes that are not on the `stack` branch will be seen as new changes, leading to unnecessary merge conflicts.

With this update, we will avoid this issue by ensuring that when a stack change occurs, the branch is created from the `stack` branch rather than the `main` branch. ✨