### PR TITLE
PNW-1651 - fix perfomance issues

### DIFF
--- a/packages/netlify-cms-widget-code/src/CodeControl.js
+++ b/packages/netlify-cms-widget-code/src/CodeControl.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { ClassNames } from '@emotion/core';
 import { Map } from 'immutable';
-import { uniq, isEqual, isEmpty } from 'lodash';
+import { uniq, isEqual, isEmpty, debounce } from 'lodash';
 import uuid from 'uuid/v4';
 import { UnControlled as ReactCodeMirror } from 'react-codemirror2';
 import CodeMirror from 'codemirror';
@@ -200,11 +200,19 @@ export default class CodeControl extends React.Component {
   }
 
   handleChange(newValue) {
+    this.setState({ lastKnownValue: newValue });
+    this.handleCodeChange(newValue);
+  }
+
+  /**
+ * When the document value changes, serialize from Slate's AST back to
+ * code and pass that up as the new value.
+ */
+  handleCodeChange = debounce(newValue => {
     const cursor = this.cm.doc.getCursor();
     const selections = this.cm.doc.listSelections();
-    this.setState({ lastKnownValue: newValue });
     this.props.onChange(this.toValue('code', newValue), { cursor, selections });
-  }
+  }, 250);
 
   showSettings = () => {
     this.setState({ settingsVisible: true });

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/RawEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/RawEditor.js
@@ -105,7 +105,7 @@ export default class RawEditor extends React.Component {
   handleDocumentChange = debounce(editor => {
     const value = Plain.serialize(editor.value);
     this.props.onChange(value);
-  }, 150);
+  }, 250);
 
   handleToggleMode = () => {
     this.props.onMode('rich_text');

--- a/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
+++ b/packages/netlify-cms-widget-markdown/src/MarkdownControl/VisualEditor.js
@@ -209,7 +209,7 @@ export default class Editor extends React.Component {
       remarkPlugins: this.remarkPlugins,
     });
     onChange(markdown);
-  }, 150);
+  }, 250);
 
   handleChange = editor => {
     if (!this.state.value.document.equals(editor.value.document)) {

--- a/packages/netlify-cms-widget-number/src/NumberControl.js
+++ b/packages/netlify-cms-widget-number/src/NumberControl.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
+import { debounce } from 'lodash';
+
 const ValidationErrorTypes = {
   PRESENCE: 'PRESENCE',
   PATTERN: 'PATTERN',
@@ -68,16 +70,15 @@ export default class NumberControl extends React.Component {
     value: '',
   };
 
+  handleNumberChange = debounce(value => {
+    const { onChange } = this.props;
+    onChange(!isNaN(value) ? value : '');
+  }, 250);
+
   handleChange = e => {
     const valueType = this.props.field.get('value_type');
-    const { onChange } = this.props;
     const value = valueType === 'float' ? parseFloat(e.target.value) : parseInt(e.target.value, 10);
-
-    if (!isNaN(value)) {
-      onChange(value);
-    } else {
-      onChange('');
-    }
+    this.handleNumberChange(value);
   };
 
   isValid = () => {

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -59,8 +59,16 @@ export default class ObjectControl extends React.Component {
    * which only updates if the value changes, but every widget must be allowed
    * to override this.
    */
-  shouldComponentUpdate() {
-    return true;
+  shouldComponentUpdate(nextProps, nextState = {}) {
+    if (this.props.forList) {
+      if (nextProps.collapsed !== this.props.collapsed) return true;
+      return !nextProps.collapsed;
+    }
+    if (nextState.collapsed !== undefined) {
+      if (nextState.collapsed !== this.state.collapsed) return true;
+      return !nextState.collapsed;
+    }
+    return !this.state.collapsed;
   }
 
   validate = () => {
@@ -176,6 +184,8 @@ export default class ObjectControl extends React.Component {
   }
 
   renderFields = (multiFields, singleField, field) => {
+    const collapsed = this.props.forList ? this.props.collapsed : this.state.collapsed;
+    if (collapsed) return;
     if (multiFields) {
       const mappedMultiFields = [];
       multiFields.forEach((f, idx) => {

--- a/packages/netlify-cms-widget-string/src/StringControl.js
+++ b/packages/netlify-cms-widget-string/src/StringControl.js
@@ -1,7 +1,15 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { debounce } from 'lodash';
 
 export default class StringControl extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: this.props.value || '',
+    };
+  }
+
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     forID: PropTypes.string,
@@ -21,6 +29,14 @@ export default class StringControl extends React.Component {
   // The input element ref
   _el = null;
 
+  shouldComponentUpdate(nextProps, nextState) {
+    return (
+      nextState &&
+      (!this.state.value === nextState.value ||
+        nextProps.value !== nextState.value)
+    );
+  }
+
   // NOTE: This prevents the cursor from jumping to the end of the text for
   // nested inputs. In other words, this is not an issue on top-level text
   // fields such as the `title` of a collection post. However, it becomes an
@@ -29,19 +45,34 @@ export default class StringControl extends React.Component {
   // within markdown.
   // SEE: https://github.com/decaporg/decap-cms/issues/4539
   // SEE: https://github.com/decaporg/decap-cms/issues/3578
-  componentDidUpdate() {
+  componentDidUpdate(prevProps) {
     if (this._el && this._el.selectionStart !== this._sel) {
       this._el.setSelectionRange(this._sel, this._sel);
+    }
+    if (prevProps.value !== this.props.value) {
+      this.setState({ value: this.props.value });
     }
   }
 
   handleChange = e => {
     this._sel = e.target.selectionStart;
-    this.props.onChange(e.target.value);
+    const { value } = e.target;
+    if (this.state.value !== value) {
+      this.handleStringChange(value);
+    }
+    this.setState({ value });
   };
 
+  /**
+   * When the document value changes, serialize from Slate's AST back to plain
+   * text and pass that up as the new value.
+   */
+  handleStringChange = debounce(value => {
+    this.props.onChange(value);
+  }, 250);
+
   render() {
-    const { forID, value, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
+    const { forID, classNameWrapper, setActiveStyle, setInactiveStyle } = this.props;
 
     return (
       <input
@@ -51,7 +82,7 @@ export default class StringControl extends React.Component {
         type="text"
         id={forID}
         className={classNameWrapper}
-        value={value || ''}
+        value={this.state.value}
         onChange={this.handleChange}
         onFocus={setActiveStyle}
         onBlur={setInactiveStyle}

--- a/packages/netlify-cms-widget-text/src/TextControl.js
+++ b/packages/netlify-cms-widget-text/src/TextControl.js
@@ -1,8 +1,16 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import Textarea from 'react-textarea-autosize';
+import { debounce } from 'lodash';
 
 export default class TextControl extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      value: this.props.value || '',
+    };
+  }
+
   static propTypes = {
     onChange: PropTypes.func.isRequired,
     forID: PropTypes.string,
@@ -27,20 +35,43 @@ export default class TextControl extends React.Component {
     return true;
   }
 
+  componentDidUpdate(prevProps) {
+    if (prevProps.value !== this.props.value) {
+      this.setState({ value: this.props.value });
+    }
+  }
+
+  handleChange = e => {
+    this._sel = e.target.selectionStart;
+    const { value } = e.target;
+    if (this.state.value !== value) {
+      this.handleStringChange(value);
+    }
+    this.setState({ value });
+  };
+
+  /**
+   * When the document value changes, serialize from Slate's AST back to
+   * number and pass that up as the new value.
+   */
+  handleStringChange = debounce(value => {
+    this.props.onChange(value);
+  }, 250);
+
   render() {
-    const { forID, value, onChange, classNameWrapper, setActiveStyle, setInactiveStyle } =
+    const { forID, classNameWrapper, setActiveStyle, setInactiveStyle } =
       this.props;
 
     return (
       <Textarea
         id={forID}
-        value={value || ''}
+        value={this.state.value || ''}
         className={classNameWrapper}
         onFocus={setActiveStyle}
         onBlur={setInactiveStyle}
         minRows={5}
         css={{ fontFamily: 'inherit' }}
-        onChange={e => onChange(e.target.value)}
+        onChange={this.handleChange}
       />
     );
   }


### PR DESCRIPTION
## ℹ️  What's this PR do?

This PR aims to improve the performance of large fields by addressing some issues that were found during `groups` functionality testing:

- Added debounce to `NumberControl`, `StringControl` and `TextControl` widgets to avoid multiple unnecessary re-renders when typing into text fields (see [10f4dc1](https://github.com/Feverup/decap-cms/pull/8/commits/10f4dc15b8081ed05b8dff39b8580a8c62dab14b))
- Implement lazy loading for `ObjectControl` to avoid long initial load times for large amounts of data (see [7810720](https://github.com/Feverup/decap-cms/pull/8/commits/78107207a374f12290c821c1771f96dd578aae43))

## 👀  Where should the reviewer start?

- `packages/netlify-cms-widget-object/src/ObjectControl.js`

## 📱  How should this be manually tested?

On `landings-cms` go to the branch `feature/PNW-1651_fix-perfomance-issues` and test:
- Debounce:
  - [ ] Test that when writing on a `Number`, `String` and `Text` widget the `debounce` work correctly and perfomance is improved
- Object render:
  - [ ] Test that the loading times have been improved
  - [ ] Test that when unfolding collapsed `Objects` the fields load correctly
  - [ ] Test that when folding collapsed `Objects` the fields hides correctly
  - [ ] Test that when unfolding collapsed `List` the fields load correctly
  - [ ] Test that when unfolding collapsed `List` the fields hides correctly
