### PR TITLE
PNW-1681 - lazy field optional

### DIFF
--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -103,7 +103,7 @@ export default class ObjectControl extends React.Component {
     if (isMap) {
       const parentName = field.get('parentName');
       if (parentName) return value.getIn([...(parentName.split('.')), fieldName]);
-      return value.get(fieldName)
+      return value.get(fieldName);
     }
 
     return value;
@@ -128,7 +128,7 @@ export default class ObjectControl extends React.Component {
       return null;
     }
 
-    const fieldValue = this.getFieldValue(field)
+    const fieldValue = this.getFieldValue(field);
 
     const isDuplicate = isFieldDuplicate && isFieldDuplicate(field);
     const isHidden = isFieldHidden && isFieldHidden(field);
@@ -184,8 +184,6 @@ export default class ObjectControl extends React.Component {
   }
 
   renderFields = (multiFields, singleField, field) => {
-    const collapsed = this.props.forList ? this.props.collapsed : this.state.collapsed;
-    if (collapsed) return;
     if (multiFields) {
       const mappedMultiFields = [];
       multiFields.forEach((f, idx) => {
@@ -221,13 +219,15 @@ export default class ObjectControl extends React.Component {
     const multiFields = field.get('fields');
     const singleField = field.get('field');
     const isFlat = field.has('flat');
+    const lazy = field.get('lazy');
+    const render = lazy ? !collapsed : true;
 
     if (multiFields || singleField) {
       return (
         <ClassNames>
           {({ css, cx }) => isFlat ? (
             <div id={forID}>
-              {this.renderFields(multiFields, singleField, field)}
+              {render && this.renderFields(multiFields, singleField, field)}
             </div>
           ) : (
             <div
@@ -264,7 +264,7 @@ export default class ObjectControl extends React.Component {
                   `]: collapsed,
                 })}
               >
-                {this.renderFields(multiFields, singleField, field)}
+                {render && this.renderFields(multiFields, singleField, field)}
               </div>
             </div>
           )}

--- a/packages/netlify-cms-widget-string/src/StringControl.js
+++ b/packages/netlify-cms-widget-string/src/StringControl.js
@@ -30,9 +30,9 @@ export default class StringControl extends React.Component {
   _el = null;
 
   shouldComponentUpdate(nextProps, nextState) {
-    return (
+    return Boolean(
       nextState &&
-      (!this.state.value === nextState.value ||
+      (this.state.value !== nextState.value ||
         nextProps.value !== nextState.value)
     );
   }


### PR DESCRIPTION
## ℹ️ What's this PR do?

- Make lazy loading optional in order to avoid issues with validation
- Fix `String` `shouldComponentUpdate`

## 👀 Where should the reviewer start?

- `packages/netlify-cms-widget-object/src/ObjectControl.js`

## 📱 How should this be tested?

Using `node 16`:
1. Run the build with `npm run build`
2. Copy the output of `packages/netify-cms/dist/netlify-cms.js` to replace it with the current one on the CMS
3. Enable `duplicate: true` to test validation

- [x] Test that validation works correctly on `Languages and cities` even if fields are collapsed
- [x] Test that lazy loading is working when `lazy: true` is set into `object` and `list`widgets

> In order to make the last test make sure to update the `constants.js` and add `lazy: true`

## 🤔 Any background context you want to provide?

When making some test we figure out that validation was only working when deep fields were not `collapsed` therefore in order to fix this we have made the `lazy loading` optional having to add `lazy` option on the `field`. This will improve perfomance but validation work won't as expected therefore `lazy` should only be used when validation is not necessary.