### PR TITLE
PNW-1681 - fixed duplicate data not loading correctly | PNW-1693 - deep list not making updates

### DIFF
--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -350,9 +350,11 @@ export default class ListControl extends React.Component {
       const withNameKey =
         this.getValueType() !== valueTypes.SINGLE ||
         (this.getValueType() === valueTypes.SINGLE && listFieldObjectWidget);
-      const newObjectValue = withNameKey
-        ? this.getObjectValue(index).set(f.get('name'), newValue)
-        : newValue;
+      const parentName = f.get('parentName');
+      const newObjectValue = withNameKey ? (parentName ?
+        this.getObjectValue(index).setIn([...parentName.split('.'), f.get('name')], newValue) :
+        this.getObjectValue(index).set(f.get('name'), newValue)) :
+        newValue;
       const parsedMetadata = {
         [collectionName]: Object.assign(metadata ? metadata.toJS() : {}, newMetadata || {}),
       };

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -60,6 +60,8 @@ export default class ObjectControl extends React.Component {
    * to override this.
    */
   shouldComponentUpdate(nextProps, nextState = {}) {
+    if (!this.props.parentIds.length) return true;
+
     if (this.props.forList) {
       if (nextProps.collapsed !== this.props.collapsed) return true;
       return !nextProps.collapsed;
@@ -99,11 +101,11 @@ export default class ObjectControl extends React.Component {
 
     const isMap = value && Map.isMap(value);
 
-    const fieldName = field.get('name');
     if (isMap) {
       const parentName = field.get('parentName');
-      if (parentName) return value.getIn([...(parentName.split('.')), fieldName]);
-      return value.get(fieldName);
+      const name = field.get('name');
+      if (parentName) return value.getIn([...(parentName.split('.')), name]);
+      return value.get(name);
     }
 
     return value;
@@ -171,8 +173,8 @@ export default class ObjectControl extends React.Component {
     const notordered = [];
     renderedFields.forEach(render => {
       const { field } = render.props;
-      const name = field.get('name');
       const parentName = field.get('parentName');
+      const name = field.get('name');
       const orderKey = parentName ? `${parentName}.${name}` : name;
       if (orderMap[orderKey]) {
         return orderMap[orderKey].push(render);
@@ -189,8 +191,8 @@ export default class ObjectControl extends React.Component {
       multiFields.forEach((f, idx) => {
         const isFlat = f.has('flat');
         if (isFlat) {
-          const name = f.get('name');
           const parentName = f.get('parentName');
+          const name = f.get('name');
 
           const fieldParentName = parentName ? `${parentName}.${name}` : name;
           const multiFields = f.get('fields')?.map(field => field.set('parentName', fieldParentName));


### PR DESCRIPTION
## ℹ️ What's this PR do?

- Add an use case on `shouldComponentUpdate` for `ObjectControl` to avoid loading data issues
- Fix deep list not changing data correctly due `parentName` functionality

## 👀 Where should the reviewer start?

- `packages/netlify-cms-widget-object/src/ObjectControl.js`
- `packages/netlify-cms-widget-list/src/ListControl.js`

## 📱 How should this be tested?

On a landing with the duplicate workflow enabled:

- [x]  Test that deep list like (subpages) on `Landing settings` are able to update correctly
- [x] Test that all dataa is being load correctly when making a duplicate of a collection

## 🤔 Any background context you want to provide?

When making some test on the duplicate workflow we figure out 2 small issues that made the workflow not working correctly. Those issues are fixed on this PR:
- Data didn't load correctly until `shouldComponentUpdate` was triggered
- Deep list wasn't loading correctly due `parentName` on deep list