### PR TITLE
PNW-1685 - added unused functionality

### DIFF
--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -242,7 +242,7 @@ class EditorControl extends React.Component {
     const hasErrors = !!errors || childErrors;
     const isFlat = widgetName === 'object' && field.has('flat');
     const styleActive = isSelected || this.state.styleActive;
-    const unused = !styleActive && this.isFieldUnused(value);
+    const unused = field.get('opacity') && (!styleActive && this.isFieldUnused(value));
 
     return (
       <ClassNames>

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js
@@ -70,7 +70,6 @@ const styleStrings = {
   `,
   unused: `
     opacity: 0.5;
-    background: #ccc;
   `
 };
 

--- a/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
+++ b/packages/netlify-cms-core/src/components/Editor/EditorControlPane/Widget.js
@@ -71,6 +71,8 @@ export default class Widget extends Component {
     isDisabled: PropTypes.bool,
     isFieldDuplicate: PropTypes.func,
     isFieldHidden: PropTypes.func,
+    isFieldUnused: PropTypes.func,
+    setFieldUnused: PropTypes.func,
     locale: PropTypes.string,
   };
 
@@ -299,6 +301,8 @@ export default class Widget extends Component {
       isDisabled,
       isFieldDuplicate,
       isFieldHidden,
+      isFieldUnused,
+      setFieldUnused,
       locale,
     } = this.props;
 
@@ -351,6 +355,8 @@ export default class Widget extends Component {
       isDisabled,
       isFieldDuplicate,
       isFieldHidden,
+      isFieldUnused,
+      setFieldUnused,
       locale,
     });
   }

--- a/packages/netlify-cms-widget-list/src/ListControl.js
+++ b/packages/netlify-cms-widget-list/src/ListControl.js
@@ -127,6 +127,8 @@ export default class ListControl extends React.Component {
     resolveWidget: PropTypes.func.isRequired,
     clearFieldErrors: PropTypes.func.isRequired,
     fieldsErrors: ImmutablePropTypes.map.isRequired,
+    isFieldUnused: PropTypes.func,
+    setFieldUnused: PropTypes.func,
     entry: ImmutablePropTypes.map.isRequired,
     t: PropTypes.func.isRequired,
   };
@@ -512,6 +514,8 @@ export default class ListControl extends React.Component {
       parentIds,
       forID,
       t,
+      isFieldUnused,
+      setFieldUnused,
     } = this.props;
 
     const { itemsCollapsed, keys } = this.state;
@@ -577,6 +581,8 @@ export default class ListControl extends React.Component {
               data-testid={`object-control-${key}`}
               hasError={hasError}
               parentIds={[...parentIds, forID, key]}
+              isFieldUnused={isFieldUnused}
+              setFieldUnused={setFieldUnused}
             />
           )}
         </ClassNames>

--- a/packages/netlify-cms-widget-object/src/ObjectControl.js
+++ b/packages/netlify-cms-widget-object/src/ObjectControl.js
@@ -88,6 +88,32 @@ export default class ObjectControl extends React.Component {
     });
   };
 
+  isFieldUnused(field) {
+    const { isFieldUnused, setFieldUnused } = this.props;
+    const isObjectField = field.get('widget') === 'object';
+    const value = this.getFieldValue(field);
+    const isUnused = isFieldUnused(value);
+    if (!isUnused) {
+      if (!isObjectField) setFieldUnused(false);
+      return false;
+    }
+    if (isObjectField) {
+      const singleField = field.get('field');
+      const multiFields = field.get('fields');
+      const fields = singleField ? [singleField] : multiFields;
+      const fieldName = field.get('name');
+      const isWrapper = field.has('wrapper');
+      const isAnyFieldUsed = fields.some(f => {
+        if (isWrapper) return !this.isFieldUnused(f)
+        const parentName = field.get('parentName');
+        const fieldParentName = parentName ? `${parentName}.${fieldName}` : fieldName;
+        return !this.isFieldUnused(f.set('parentName', fieldParentName));
+      });
+      if (isAnyFieldUsed) return false;
+    }
+    return true;
+  }
+
   getFieldValue(field) {
     const { value } = this.props;
 
@@ -223,6 +249,8 @@ export default class ObjectControl extends React.Component {
     const isFlat = field.has('flat');
     const lazy = field.get('lazy');
     const render = lazy ? !collapsed : true;
+    const opacity = field.get('opacity');
+    if (opacity) this.isFieldUnused(field);
 
     if (multiFields || singleField) {
       return (


### PR DESCRIPTION
## ℹ️  What's this PR do?

- Add the possibility to add `opacity: true` to any field in order to set opacity to `.5` when the field is not being used

## 👀  Where should the reviewer start?

- `packages/netlify-cms-core/src/components/Editor/EditorControlPane/EditorControl.js`


## 📱  How should this be manually tested?

Make the build with `npm run build` and copy the output to the CMS.

- [x] Test that either objects and fields appear with opacity .5 when they don't have value on the `yml` when `opactiry: true` is set
- [x] Test that when `opacity` is not set the fields load as always

## 🤔  Any background context you want to provide?
Wee need a way to make clear to the user if the module is being used by a collection or not. In order to make this easier to understand we will set `opacity .5` to the module when is not begin used. (Only when `opacity: true` is set)

