### PR TITLE
PNW-2019 - Fix rebase to make it correctly on stack change use case

### DIFF
--- a/packages/netlify-cms-backend-github/src/API.ts
+++ b/packages/netlify-cms-backend-github/src/API.ts
@@ -1033,7 +1033,7 @@ export default class API {
     } else {
       // Entry is already on editorial review workflow - commit to existing branch
       const { files: diffFiles } = await this.getDifferences(
-        this.branch,
+        this.getCurrentBranch(),
         await this.getHeadReference(branch),
       );
 
@@ -1133,7 +1133,7 @@ export default class API {
     try {
       // Get the diff between the default branch the published branch
       const { base_commit: baseCommit, commits } = await this.getDifferences(
-        this.branch,
+        this.getCurrentBranch(),
         await this.getHeadReference(branch),
       );
       // Rebase the branch based on the diff
@@ -1178,7 +1178,7 @@ export default class API {
       } else if (newStatus === 'pending_review') {
         const branch = branchFromContentKey(contentKey);
         // get the first commit message as the pr title
-        const diff = await this.getDifferences(this.branch, await this.getHeadReference(branch));
+        const diff = await this.getDifferences(this.getCurrentBranch(), await this.getHeadReference(branch));
         const title = diff.commits[0]?.commit?.message || API.DEFAULT_COMMIT_MESSAGE;
         await this.createPR(title, branch);
       }
@@ -1450,7 +1450,7 @@ export default class API {
     return this.getDefaultBranch()
       .then(branchData => this.updateTree(branchData.commit.sha, files))
       .then(changeTree => this.commit(commitMessage, changeTree))
-      .then(response => this.patchBranch(this.branch, response.sha));
+      .then(response => this.patchBranch(this.getCurrentBranch(), response.sha));
   }
 
   async mergeAndCleanPR(pullRequest: GitHubPull, options: { force?: boolean } = {}) {


### PR DESCRIPTION
## ℹ️ What's this PR do?

- Update `rebase` branch to don't create conflicts when changes are made

## 👀 Where should the reviewer start?

- `packages/netlify-cms-backend-github/src/API.ts`

## 📱 How should this be tested?

> As reviewer, remember you always have to test the code locally on your machine. To do so follow these instructions:
>
> 1. Checkout the PR branch
> 2. Start the landing you want to test by running `npm run dev <landing-name>`
> 3. You will have the site available at `http://localhost:8000`
>
> Do you need to start multiple landings affected in a git diff?
>
> 1. Checkout the PR branch
> 2. Find the commit SHA you want to diff from
> 3. Start the landings affected in a git diff with commit SHA like this: `npm run dev -- --diff=<COMMIT_SHA>`
> 4. Check out this confluence page for more details about diff in monorepo [here](https://feverup.atlassian.net/wiki/spaces/LAN/pages/2604924929/Turborepo+Landings+HBS+Monorepo#Understanding---diff)

To test this we should:
1. Create a test branch to reproduce the use case.
2. Update the main branch on the CMS to the created branch

Now that we have the basic setup let's reproduce the use case, in order to reproduce this issue follow this steps:
 1. Create a `stack` change
 2. Make a change in a collection.
 3. Update is made on `master`
 4. Another change is introduced to the same collection that was altered in step 2.

- [ ] Test that with `feature/PNW-2019_rebase-fix` the `rebase` is not beign made with the `main` branch