### PR TITLE
PNW-2478 - updated delete workflow to make it work with all integrations

### DIFF
--- a/packages/decap-cms-core/src/actions/editorialWorkflow.ts
+++ b/packages/decap-cms-core/src/actions/editorialWorkflow.ts
@@ -558,23 +558,29 @@ export function unpublishPublishedEntry(collection: Collection, slug: string) {
     dispatch(unpublishedEntryPersisting(collection, slug));
     return backend
       .deleteEntry(state, collection, slug)
-      .then(() =>
-        backend.persistEntry({
-          config: state.config,
-          collection,
-          entryDraft,
-          assetProxies: [],
-          usedSlugs: List(),
-          status: status.get('PENDING_PUBLISH'),
-        }),
-      )
+      .then(() => {
+        if (!backend.implementation.deleteCollectionFiles) {
+          backend.persistEntry({
+            config: state.config,
+            collection,
+            entryDraft,
+            assetProxies: [],
+            usedSlugs: List(),
+            status: status.get('PENDING_PUBLISH'),
+          });
+        }
+      })
       .then(() => {
         dispatch(unpublishedEntryPersisted(collection, entry));
         dispatch(entryDeleted(collection, slug));
         dispatch(loadUnpublishedEntry(collection, slug));
         dispatch(
           addNotification({
-            message: { key: 'ui.toast.entryUnpublished' },
+            message: {
+              key: backend.implementation.deleteCollectionFiles
+                ? 'ui.toast.entryBeingUnpublished'
+                : 'ui.toast.entryUnpublished',
+            },
             type: 'success',
             dismissAfter: 4000,
           }),

--- a/packages/decap-cms-core/src/actions/entries.ts
+++ b/packages/decap-cms-core/src/actions/entries.ts
@@ -17,7 +17,7 @@ import { waitForMediaLibraryToLoad, loadMedia } from './mediaLibrary';
 import { waitUntil } from './waitUntil';
 import { selectIsFetching, selectEntriesSortFields, selectEntryByPath } from '../reducers/entries';
 import { selectCustomPath } from '../reducers/entryDraft';
-import { navigateToEntry } from '../routing/history';
+import { navigateToCollection, navigateToEntry } from '../routing/history';
 import { getProcessSegment } from '../lib/formatters';
 import { hasI18n, duplicateDefaultI18nFields, serializeI18n, I18N, I18N_FIELD } from '../lib/i18n';
 import { loadUnpublishedEntry } from './editorialWorkflow';
@@ -982,16 +982,22 @@ export function deleteEntry(collection: Collection, slug: string) {
       .deleteEntry(state, collection, slug)
       .then(async () => {
         dispatch(entryDeleted(collection, slug));
-        dispatch(loadUnpublishedEntry(collection, slug));
         dispatch(
           addNotification({
             message: {
-              key: 'ui.toast.entryBeingUnpublished',
+              key: backend.implementation.deleteCollectionFiles
+                ? 'ui.toast.entryBeingUnpublished'
+                : 'ui.toast.entryUnpublished',
             },
             type: 'success',
             dismissAfter: 4000,
           }),
         );
+        if (backend.implementation.deleteCollectionFiles) {
+          dispatch(loadUnpublishedEntry(collection, slug));
+        } else {
+          navigateToCollection(collection.get('name'));
+        }
       })
       .catch((error: Error) => {
         dispatch(

--- a/packages/decap-cms-core/src/backend.ts
+++ b/packages/decap-cms-core/src/backend.ts
@@ -1291,12 +1291,17 @@ export class Backend {
     if (hasI18n(collection)) {
       paths = getFilePaths(collection, extension, path, slug);
     }
-    await this.implementation.deleteCollectionFiles(
-      paths,
-      commitMessage,
-      collection.get('name'),
-      slug,
-    );
+
+    if (this.implementation.deleteCollectionFiles) {
+      await this.implementation.deleteCollectionFiles(
+        paths,
+        commitMessage,
+        collection.get('name'),
+        slug,
+      );
+    } else {
+      await this.implementation.deleteFiles(paths, commitMessage);
+    }
 
     await this.invokePostUnpublishEvent(entry);
   }

--- a/packages/decap-cms-lib-util/src/implementation.ts
+++ b/packages/decap-cms-lib-util/src/implementation.ts
@@ -156,7 +156,7 @@ export interface Implementation {
   persistEntry: (entry: Entry, opts: PersistOptions) => Promise<void>;
   persistMedia: (file: AssetProxy, opts: PersistOptions) => Promise<ImplementationMediaFile>;
   deleteFiles: (paths: string[], commitMessage: string) => Promise<void>;
-  deleteCollectionFiles: (
+  deleteCollectionFiles?: (
     paths: string[],
     commitMessage: string,
     collection: string,


### PR DESCRIPTION
## ℹ️ What's this PR do?
- Fix delete workflow integration
  - **feat: updated delete workflow to make it work with all integrations**

## 👀 Where should the reviewer start?

- `packages/decap-cms-core/src/backend.ts`

## 📱 How should this be tested?

> As reviewer, remember you always have to test the code locally on your machine. To do so follow these instructions:
>
> 1. Checkout the PR branch
> 2. Start the landing you want to test by running `npm run dev <landing-name>`
> 3. You will have the site available at `http://localhost:8000`
>
> Do you need to start multiple landings affected in a git diff?
>
> 1. Checkout the PR branch
> 2. Find the commit SHA you want to diff from
> 3. Start the landings affected in a git diff with commit SHA like this: `npm run dev -- --diff=<COMMIT_SHA>`
> 4. Check out this confluence page for more details about diff in monorepo [here](https://feverup.atlassian.net/wiki/spaces/LAN/pages/2604924929/Turborepo+Landings+HBS+Monorepo#Understanding---diff)

- [x] Test that local proxy does the remove workflow properly
- [x] Test that github integration does the remove workflow properly

## 🤔 Any background context you want to provide?
Since the update of `netlify-cms` to `decap-cms` we were experiencing some issues with the delete workflow on this PR we wil fix them