### PR TITLE
PNW-2564 - recover isFieldUnused on ListControl

### DIFF
--- a/packages/decap-cms-widget-list/src/ListControl.js
+++ b/packages/decap-cms-widget-list/src/ListControl.js
@@ -673,6 +673,8 @@ export default class ListControl extends React.Component {
       t,
       collection,
       collections,
+      isFieldUnused,
+      setFieldUnused,
     } = this.props;
 
     const { itemsCollapsed, keys } = this.state;
@@ -747,6 +749,8 @@ export default class ListControl extends React.Component {
               data-testid={`object-control-${key}`}
               hasError={hasError}
               parentIds={[...parentIds, forID, key]}
+              isFieldUnused={isFieldUnused}
+              setFieldUnused={setFieldUnused}
             />
           )}
         </ClassNames>


### PR DESCRIPTION
On this PR we accidentally remove a props passing https://github.com/Feverup/decap-cms/pull/21. Creating an error on `(Old)` CMS.

On this PR we will fix this.