### PR TITLE
PNW-2730 - updated logic to handle empty label use case

### DIFF
--- a/packages/decap-cms-backend-github/src/API.ts
+++ b/packages/decap-cms-backend-github/src/API.ts
@@ -845,8 +845,7 @@ export default class API {
     }
 
     console.log(
-      `Done migrating Pull Request '${
-        number === newNumber ? newNumber : `${number} => ${newNumber}`
+      `Done migrating Pull Request '${number === newNumber ? newNumber : `${number} => ${newNumber}`
       }'`,
     );
   }
@@ -856,6 +855,26 @@ export default class API {
       `${this.repoURL}/git/refs/heads/cms/${this.repo}`,
     ).catch(() => [] as Octokit.GitListMatchingRefsResponseItem[]);
     return cmsBranches;
+  }
+
+  async getCmsRefs() {
+    const cmsPullRequestsNoLabel: GitHubPull[] = [];
+    const cmsPullRequests = await this.getPullRequests(undefined, PullRequestState.Open, pr => {
+      const hasRefSuffix = withCmsRefSuffix(pr);
+      if (!hasRefSuffix) return false;
+
+      const prLabeled = withCmsLabel(pr, this.cmsLabelPrefix)
+      if (!prLabeled) {
+        cmsPullRequestsNoLabel.push(pr);
+      }
+      return true;
+    });
+
+    for (const pr of cmsPullRequestsNoLabel) {
+      await this.setPullRequestStatus(pr, this.initialWorkflowStatus);
+    }
+
+    return cmsPullRequests.map(pr => pr.head.ref);
   }
 
   async listUnpublishedBranches() {
@@ -895,10 +914,8 @@ export default class API {
       //     prCount = prCount + 1;
       //     await this.migratePullRequest(pr, `${prCount} of ${pullRequests.length}`);
       //   }
-      const cmsPullRequests = await this.getPullRequests(undefined, PullRequestState.Open, pr =>
-        withCmsLabel(pr, this.cmsLabelPrefix),
-      );
-      branches = cmsPullRequests.map(pr => pr.head.ref);
+
+      branches = await this.getCmsRefs();
     }
 
     return branches;
@@ -1175,6 +1192,8 @@ export default class API {
   }
 
   async setPullRequestStatus(pullRequest: GitHubPull, newStatus: string) {
+    if (!newStatus) return;
+
     const labels = [
       ...pullRequest.labels
         .filter(label => !isCMSLabel(label.name, this.cmsLabelPrefix))
@@ -1655,6 +1674,14 @@ export default class API {
     this.useStack = false;
   }
 
+  async getStackLabel(pullRequest: GitHubPull): Promise<{ name: string }> {
+    const label = pullRequest.labels.find(l => isCMSLabel(l.name, this.cmsLabelPrefix));
+    if (label) return label;
+    const initialStatus = this.initialWorkflowStatus;
+    await this.updateStackStatus(initialStatus);
+    return { name: statusToLabel(initialStatus, this.cmsLabelPrefix) };
+  }
+
   async fetchStack() {
     if (!this.stack) return;
 
@@ -1665,9 +1692,7 @@ export default class API {
     const pullRequest = await this.getStackPullRequest();
     if (!pullRequest) return;
 
-    const label = pullRequest.labels.find(l => isCMSLabel(l.name, this.cmsLabelPrefix)) as {
-      name: string;
-    };
+    const label = await this.getStackLabel(pullRequest);
     const status = labelToStatus(label.name, this.cmsLabelPrefix);
     const updatedAt = pullRequest.updated_at;
     return {

--- a/packages/decap-cms-core/src/actions/editorialWorkflow.ts
+++ b/packages/decap-cms-core/src/actions/editorialWorkflow.ts
@@ -335,7 +335,7 @@ export function persistUnpublishedEntry(
     const state = getState();
     const entryDraft = customEntryDraft || state.entryDraft;
     const isCustomEntry = customEntryDraft && entryDraft.getIn(['entry', 'isCustomEntry'], true);
-    const status = customEntryDraft && customEntryDraft.getIn(['entry', 'status']);
+    const customEntryStatus = customEntryDraft && customEntryDraft.getIn(['entry', 'status']);
     const fieldsErrors = entryDraft.get('fieldsErrors');
     const unpublishedSlugs = selectUnpublishedSlugs(state, collection.get('name'));
     const publishedSlugs = selectPublishedSlugs(state, collection.get('name'));
@@ -385,7 +385,7 @@ export function persistUnpublishedEntry(
         assetProxies,
         usedSlugs,
         context,
-        status,
+        status: customEntryStatus,
       });
       dispatch(
         addNotification({
@@ -572,6 +572,7 @@ export function publishUnpublishedEntry(
 export function unpublishPublishedEntry(
   collection: Collection,
   slug: string,
+  context: HookContext,
   customEntry?: EntryMap,
 ) {
   return (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
@@ -582,7 +583,7 @@ export function unpublishPublishedEntry(
     const entryDraft = Map().set('entry', entry) as unknown as EntryDraft;
     dispatch(unpublishedEntryPersisting(collection, slug));
     return backend
-      .deleteEntry(state, collection, slug)
+      .deleteEntry(state, collection, slug, context, customEntry)
       .then(() => {
         if (!backend.implementation.deleteCollectionFiles) {
           backend.persistEntry({

--- a/packages/decap-cms-core/src/actions/entries.ts
+++ b/packages/decap-cms-core/src/actions/entries.ts
@@ -932,7 +932,7 @@ export function persistEntry(
     const backend = currentBackend(state.config);
     const entry = entryDraft.get('entry');
     const isCustomEntry = customEntryDraft && entry.get('isCustomEntry', true);
-    const status = customEntryDraft && entry.get('status');
+    const customEntryStatus = customEntryDraft && entry.get('status');
     const assetProxies = getMediaAssets({
       entry,
     });
@@ -950,7 +950,7 @@ export function persistEntry(
         assetProxies,
         usedSlugs,
         context,
-        status,
+        status: customEntryStatus,
       })
       .then(async (newSlug: string) => {
         dispatch(
@@ -1004,16 +1004,16 @@ export function deleteEntry(
   collection: Collection,
   slug: string,
   context: HookContext,
-  entry?: EntryMap,
+  customEntry?: EntryMap,
 ) {
   return (dispatch: ThunkDispatch<State, {}, AnyAction>, getState: () => State) => {
     const state = getState();
     const backend = currentBackend(state.config);
-    const isCustomEntry = entry && entry.get('isCustomEntry', true);
+    const isCustomEntry = customEntry && customEntry.get('isCustomEntry', true);
 
     dispatch(entryDeleting(collection, slug));
     return backend
-      .deleteEntry(state, collection, slug, context, entry)
+      .deleteEntry(state, collection, slug, context, customEntry)
       .then(async () => {
         dispatch(entryDeleted(collection, slug));
         dispatch(


### PR DESCRIPTION
## ℹ️ What's this PR do?

This PR introduces a self-healing mechanism to the editorial workflow to handle cases where a Pull Request fails to get labeled upon creation, making it more resilient. It also includes a fix for the entry deletion process.

-   **Proactive PR Labeling**: Implements a new `getCmsRefs` function in `API.ts` that fetches all open PRs matching the CMS branch prefix. If a PR is found without a CMS status label, it automatically applies the default `initialWorkflowStatus`, ensuring no entry becomes "invisible" to the workflow.
-   **Resilient Stack Handling**: Adds a `getStackLabel` helper to ensure the stack's PR always has a valid status label, applying one on-the-fly if it's missing to prevent processing errors.
-   **Fix Delete Workflow**: Corrects the logic in `editorialWorkflow.ts` and `entries.ts` to properly pass the `customEntry` context during unpublishing/deletion operations.

---

## 👀 Where should the reviewer start?

-   `packages/decap-cms-backend-github/src/API.ts`: Review the new `getCmsRefs` and `getStackLabel` functions, which contain the core logic for the self-healing mechanism.
-   `packages/decap-cms-core/src/actions/editorialWorkflow.ts`: Inspect the changes for the delete entry workflow fix.
-   `packages/decap-cms-core/src/actions/entries.ts`: Review the related context-passing fix for entry deletion.

---

## 📱 How should this be tested?

> As reviewer, remember you always have to test the code locally on your machine. To do so follow these instructions:
>
> 1. Checkout the PR branch
> 2. Build your packages if necessary with `npm run build`
>
> In order to test the library in a local project, you need to execute `npm link`. Follow the instruction from the [documentation](https://feverup.atlassian.net/wiki/spaces/LAN/pages/2789867537/Landings+New+Tech+Astro+and+modular+CMS#Local-development-setup) in order to setup the development environment.

On `landings-cms` checkout to `feat/PNW-2730_label-missing-improvements` to make all the following tests

-   [x] **Test Case 1: Unlabeled PR Recovery**
    1.  Create a new entry in the CMS and let it create a PR.
    2.  Quickly go to the PR on GitHub and manually remove the `netlify-cms/draft` label before the CMS polls again.
    3.  Return to the CMS workflow UI.
    4.  Verify that after a short time, the entry correctly appears in the workflow, and the label has been re-applied to the PR on GitHub.

-   [ ] **Test Case 2: Standard Workflow (Regression Test)**
    1.  Create, update, and publish a new entry.
    2.  Verify that the entire process works smoothly without any new issues.

-   [ ] **Test Case 3: Delete/Unpublish Workflow**
    1.  Select a published entry that can be unpublished.
    2.  Use the "Unpublish" action in the CMS.
    3.  Verify that the process completes successfully and the entry is correctly removed or moved to the workflow.

---

## 🤔 Any background context you want to provide?

**Problem:** Occasionally, the GitHub API fails to apply a status label (e.g., `netlify-cms/draft`) to a newly created PR. This makes the PR "invisible" to the CMS, blocking the user from viewing, editing, or publishing their changes via the editorial workflow.

**Solution:** This PR refactors the GitHub backend to be resilient to this failure. Instead of only fetching PRs that are already labeled, the backend now fetches all relevant open PRs, identifies any without a CMS label, and automatically applies the default initial status. This creates a self-healing system that ensures every entry is correctly tracked.

This work is based on the technical study from **[PNW-2728](https://feverup.atlassian.net/browse/PNW-2728)**.

[PNW-2728]: https://feverup.atlassian.net/browse/PNW-2728?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ